### PR TITLE
Use forward slash instead of path sep

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "ical",
 	"name": "iCal",
-	"version": "1.7.1",
+	"version": "1.8.0",
 	"minAppVersion": "0.15.0",
 	"description": "Scans your vault for tasks. Creates an iCal file and stores it on Gist. You can then show this calendar in any iCal compatible client such as Outlook, Google Calendar, Apple Calendar, etc.",
 	"author": "Andrew Brereton",

--- a/src/FileClient.ts
+++ b/src/FileClient.ts
@@ -1,5 +1,4 @@
-import { FileSystemAdapter, TFile, Vault } from "obsidian";
-import * as path from "path";
+import { TFile, Vault } from "obsidian";
 
 export class FileClient {
   vault: Vault;
@@ -15,7 +14,7 @@ export class FileClient {
   }
 
   async save(calendar: string) {
-    const fileRelativePath = `${this.filePath ?? this.filePath + path.sep}${this.fileName}${this.fileExtension}`;
+    const fileRelativePath = `${this.filePath ?? this.filePath + '/'}${this.fileName}${this.fileExtension}`;
     const file = this.vault.getAbstractFileByPath(fileRelativePath);
 
     if (file instanceof TFile) {

--- a/src/IcalService.ts
+++ b/src/IcalService.ts
@@ -8,7 +8,7 @@ export class IcalService {
     let calendar = '' +
       'BEGIN:VCALENDAR\r\n' +
       'VERSION:2.0\r\n' +
-      'PRODID:-//Andrew Brereton//obsidian-ical-plugin v1.7.1//EN\r\n' +
+      'PRODID:-//Andrew Brereton//obsidian-ical-plugin v1.8.0//EN\r\n' +
       'X-WR-CALNAME:Obsidian Calendar\r\n' +
       'NAME:Obsidian Calendar\r\n' +
       'CALSCALE:GREGORIAN\r\n' +


### PR DESCRIPTION
Use '/' instead of importing path. Removing the nodejs impor
t so it will work on mobile. Obsidian will normalise the path separator for me.

Based on feedback from @liamcain https://github.com/obsidianmd/obsidian-releases/pull/2587\#issuecomment-1834355884