### PR TITLE
Allow user to exclude tasks from the past.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,14 @@ This option will remove them entirely from your event summary.
 
 This is to allow you to exclude completed tasks from being added to your calendar. It will also remove tasks from your calendar once they are marked as completed.
 
+### Ignore old tasks?
+
+Toggles on or off the functionality where you are able to exclude tasks whose dates are older than the value you specify.
+
+### How many days back to you want to keep old tasks?
+
+If `Ignore old tasks?` is true then you will be asked to set the age in days. Minimum value is 1 day. Maximum value is 3650 days (10 years).
+
 ### Save calendar to GitHub Gist?
 
 Enabling this will unlock the [Save calendar to GitHub Gist](README.md#save-calendar-to-gitHub-gist) settings.

--- a/src/Main.ts
+++ b/src/Main.ts
@@ -23,7 +23,7 @@ export class Main {
     this.githubClient = new GithubClient(this.settings.githubPersonalAccessToken, this.settings.githubGistId, this.settings.filename);
     this.fileClient = new FileClient(this.app.vault, this.settings.savePath, this.settings.saveFileName, this.settings.saveFileExtension);
     this.tasks = [];
-    this.taskFinder = new TaskFinder(this.app.vault, this.settings.howToParseInternalLinks, this.settings.ignoreCompletedTasks);
+    this.taskFinder = new TaskFinder(this.app.vault, this.settings.howToParseInternalLinks, this.settings.ignoreCompletedTasks, this.settings.ignoreOldTasks, this.settings.oldTaskInDays);
   }
 
   async start() {

--- a/src/Model/Settings.ts
+++ b/src/Model/Settings.ts
@@ -20,6 +20,8 @@ export interface Settings {
   howToParseInternalLinks: string;
   ignoreCompletedTasks: boolean;
   isDebug: boolean;
+  ignoreOldTasks: boolean;
+  oldTaskInDays: number;
 }
 
 export const DEFAULT_SETTINGS: Settings = {
@@ -37,6 +39,8 @@ export const DEFAULT_SETTINGS: Settings = {
   howToParseInternalLinks: HOW_TO_PARSE_INTERNAL_LINKS.DoNotModifyThem,
   ignoreCompletedTasks: false,
   isDebug: false,
+  ignoreOldTasks: false,
+  oldTaskInDays: 365,
 };
 
 export function settingsWithoutSecrets(settings: Settings): Settings {

--- a/src/SettingTab.ts
+++ b/src/SettingTab.ts
@@ -42,7 +42,7 @@ export class SettingTab extends PluginSettingTab {
       );
 
     new Setting(containerEl)
-      .setName('Ignore completed tasks')
+      .setName('Ignore completed tasks?')
       .setDesc('Choose if you want your calendar to ignore tasks that have been completed.')
       .addToggle((toggle: ToggleComponent) =>
         toggle
@@ -53,6 +53,36 @@ export class SettingTab extends PluginSettingTab {
             this.display();
           })
       );
+
+    new Setting(containerEl)
+      .setName('Ignore old tasks?')
+      .setDesc('Do you want to exclude tasks if they are older than a certain age? This could be useful if you have a very large number of tasks and are not interested in the past.')
+      .addToggle((toggle: ToggleComponent) =>
+        toggle
+          .setValue(this.plugin.settings.ignoreOldTasks)
+          .onChange(async (value) => {
+            this.plugin.settings.ignoreOldTasks = value;
+            await this.plugin.saveSettings();
+            this.display();
+          })
+      );
+
+    if (this.plugin.settings.ignoreOldTasks) {
+      new Setting(containerEl)
+        .setName('How many days back to you want to keep old tasks?')
+        .setDesc('If every date for a given task is more than this many days ago then it will be excluded from your calendar.')
+        .addText((text) =>
+          text
+            .setValue(this.plugin.settings.oldTaskInDays.toString())
+            .onChange(async (value) => {
+              let days: number = parseInt(value, 10);
+              if (days < 0) days = 1;
+              if (days > 3650) days = 3650;
+              this.plugin.settings.oldTaskInDays = days;
+              await this.plugin.saveSettings();
+            })
+        );
+    }
 
     new Setting(containerEl)
       .setName('Save calendar to GitHub Gist?')

--- a/src/TaskFinder.ts
+++ b/src/TaskFinder.ts
@@ -5,11 +5,15 @@ export class TaskFinder {
   private vault: Vault;
   private howToParseInternalLinks: string;
   private ignoreCompletedTasks: boolean;
+  private ignoreOldTasks: boolean;
+  private oldTaskInDays: number
 
-  constructor(vault: Vault, howToParseInternalLinks: string, ignoreCompletedTasks: boolean) {
+  constructor(vault: Vault, howToParseInternalLinks: string, ignoreCompletedTasks: boolean, ignoreOldTasks: boolean, oldTaskInDays: number) {
     this.vault = vault;
     this.howToParseInternalLinks = howToParseInternalLinks;
     this.ignoreCompletedTasks = ignoreCompletedTasks;
+    this.ignoreOldTasks = ignoreOldTasks;
+    this.oldTaskInDays = oldTaskInDays;
   }
 
   async findTasks(file: TFile, listItemsCache: ListItemCache[]): Promise<Task[]> {
@@ -23,7 +27,7 @@ export class TaskFinder {
       // Get the line
       .map((idx) => lines[idx])
       // Create a Task from the line
-      .map((line: string) => createTaskFromLine(line, fileUri, this.howToParseInternalLinks, this.ignoreCompletedTasks))
+      .map((line: string) => createTaskFromLine(line, fileUri, this.howToParseInternalLinks, this.ignoreCompletedTasks, this.ignoreOldTasks, this.oldTaskInDays))
       // Filter out the nulls
       .filter((task: Task | null) => task !== null) as Task[]
       ;


### PR DESCRIPTION
If every date for a given task (eg: Created, Scheduled, Start, Due, Done, etc) is older than the specified time, then it will be excluded from the iCalendar.

Fixes #39
