### PR TITLE
Allow user to choose which dates are used.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Obsidian supports two types of [internal link](https://help.obsidian.md/Linking+
 
 Wikilinks can look like: `[[Link to document]]` or `[[Link to document|Link title]]`. Markdown links look like `[Link title](Link to document)`.
 
-#### Do not modify them
+#### Do not modify them (default)
 
 This option will keep the links in your event just as they appear.
 
@@ -57,6 +57,36 @@ Toggles on or off the functionality where you are able to exclude tasks whose da
 ### How many days back to you want to keep old tasks?
 
 If `Ignore old tasks?` is true then you will be asked to set the age in days. Minimum value is 1 day. Maximum value is 3650 days (10 years).
+
+### Which task date should be used?
+
+Tasks can have one or more dates. From either a single raw date in YYYY-MM-DD format, to dates for when a task starts, is scheduled or is due. This setting is to customise which date is chosen when building your iCalendar.
+
+#### Prefer due date (default)
+
+Prefer due date means the following sequence will be followed:
+
+1. If the task has a due date and a start date, they will be the start and end date
+1. If the task only has a due date, that will be used
+1. If the task only has a start date, that will be used
+1. If neither are found, just find any date related to that task
+
+#### Prefer start date
+
+Prefer start date means the following sequence will be followed:
+
+1. If the task only has a start date, that will be used
+1. If the task only has a due date, that will be used
+1. If neither are found, just find any date related to that task
+
+#### Create an event per start/scheduled/due date
+
+Create an event for each start date, scheduled date and due date associated with a task. This means if your task has all three dates, then three separate events will be created in your calendar.
+
+1. If there is a start date, an event will be created using that date. The summary will be appended with a 🛫.
+1. If there is a scheduled date, an event will be created using that date. The summary will be appended with a ⏳.
+1. If there is a due date, an event will be created using that date. The summary will be appended with a 📅.
+1. If none of the above dates were found, then take any old date that we can find
 
 ### Save calendar to GitHub Gist?
 

--- a/src/IcalService.ts
+++ b/src/IcalService.ts
@@ -1,7 +1,14 @@
 import { Task } from './Model/Task';
 import { TaskDateName } from './Model/TaskDate';
+import { HOW_TO_PROCESS_MULTIPLE_DATES } from './Model/Settings';
 
 export class IcalService {
+  private howToProcessMultipleDates: string;
+
+  constructor(howToProcessMultipleDates: string) {
+    this.howToProcessMultipleDates = howToProcessMultipleDates;
+  }
+
   getCalendar(tasks: Task[]): string {
     const events = this.getEvents(tasks);
 
@@ -24,35 +31,96 @@ export class IcalService {
   private getEvents(tasks: Task[]): string {
     return tasks
       .map((task: Task) => {
-        return this.getEvent(task);
+        return this.getEvent(task, null, '');
       })
       .join('');
   }
 
-  private getEvent(task: Task): string {
+  private getEvent(task: Task, date: string|null, prependSummary: string): string {
     // console.log({task});
     let event = '' +
       'BEGIN:VEVENT\r\n' +
       'UID:' + task.getId() + '\r\n' +
       'DTSTAMP:' + task.getDate(null, 'YYYYMMDDTHHmmss') + '\r\n';
 
-    if (task.hasA(TaskDateName.Start) && task.hasA(TaskDateName.Due)) {
-      event += '' +
-        'DTSTART:' + task.getDate(TaskDateName.Start, 'YYYYMMDDTHHmmss') + '\r\n' +
-        'DTEND:' + task.getDate(TaskDateName.Due, 'YYYYMMDDTHHmmss') + '\r\n';
-    } else if (task.hasA(TaskDateName.Start)) {
-      event += '' +
-        'DTSTART:' + task.getDate(TaskDateName.Start, 'YYYYMMDD') + '\r\n';
-    } else if (task.hasA(TaskDateName.Due)) {
-      event += '' +
-        'DTSTART:' + task.getDate(TaskDateName.Due, 'YYYYMMDD') + '\r\n';
+    if (date === null) {
+
+      switch (this.howToProcessMultipleDates) {
+
+        // User would prefer to use the task's start date
+        // If a start date does not exist, take the due date
+        // If a due date does not exist, take any old date that we can find
+        case 'PreferStartDate':
+          if (task.hasA(TaskDateName.Start)) {
+            event += 'DTSTART:' + task.getDate(TaskDateName.Start, 'YYYYMMDD') + '\r\n';
+          } else if (task.hasA(TaskDateName.Due)) {
+            event += 'DTSTART:' + task.getDate(TaskDateName.Due, 'YYYYMMDD') + '\r\n';
+          } else {
+            event += 'DTSTART:' + task.getDate(null, 'YYYYMMDD') + '\r\n';
+          }
+
+          break;
+
+        // User would prefer to create an event per task date
+        // If there is a start date, then create an event for it
+        // If there is a schedule date, then create an event for it
+        // If there is a due date, then create an event for it
+        // If there are no events, then take any old date that we can find
+        case 'CreateMultipleEvents':
+          let events = '';
+
+          if (task.hasA(TaskDateName.Start)) {
+            events += this.getEvent(task, task.getDate(TaskDateName.Start, 'YYYYMMDD'), '🛫 ');
+          }
+
+          if (task.hasA(TaskDateName.Scheduled)) {
+            events += this.getEvent(task, task.getDate(TaskDateName.Scheduled, 'YYYYMMDD'), '⏳ ');
+          }
+
+          if (task.hasA(TaskDateName.Due)) {
+            events += this.getEvent(task, task.getDate(TaskDateName.Due, 'YYYYMMDD'), '📅 ');
+          }
+
+          if (event === '') {
+            events += this.getEvent(task, task.getDate(null, 'YYYYMMDD'), '');
+          }
+
+          return events;
+
+          break;
+
+        // User would prefer to use the task's due date
+        // If there is a start and due date, set the start to the start date and the end to the due date
+        // If a start and due date does not exist, take the due date
+        // If a due date does not exist, take the start date
+        // If a start date does not exist, take any old date that we can find
+        case 'PreferDueDate':
+        default:
+          if (task.hasA(TaskDateName.Start) && task.hasA(TaskDateName.Due)) {
+            event += '' +
+              'DTSTART:' + task.getDate(TaskDateName.Start, 'YYYYMMDDTHHmmss') + '\r\n' +
+              'DTEND:' + task.getDate(TaskDateName.Due, 'YYYYMMDDTHHmmss') + '\r\n';
+          } else if (task.hasA(TaskDateName.Due)) {
+            event += '' +
+              'DTSTART:' + task.getDate(TaskDateName.Due, 'YYYYMMDD') + '\r\n';
+          } else if (task.hasA(TaskDateName.Start)) {
+            event += '' +
+              'DTSTART:' + task.getDate(TaskDateName.Start, 'YYYYMMDD') + '\r\n';
+          } else {
+            event += '' +
+              'DTSTART:' + task.getDate(null, 'YYYYMMDD') + '\r\n';
+          }
+
+          break;
+      }
     } else {
+      // Date has been given to this function which means we are being called recursively due to CreateMultipleEvents
       event += '' +
-        'DTSTART:' + task.getDate(null, 'YYYYMMDD') + '\r\n';
+        'DTSTART:' + date + '\r\n';
     }
 
     event += '' +
-      'SUMMARY:' + task.getSummary() + '\r\n' +
+      'SUMMARY:' + prependSummary + task.getSummary() + '\r\n' +
       'LOCATION:ALTREP="' + encodeURI(task.getLocation()) + '":' + encodeURI(task.getLocation()) + '\r\n' +
       'END:VEVENT\r\n';
 

--- a/src/Main.ts
+++ b/src/Main.ts
@@ -19,7 +19,7 @@ export class Main {
   constructor(app: App, settings: Settings) {
     this.app = app;
     this.settings = settings;
-    this.iCalService = new IcalService();
+    this.iCalService = new IcalService(this.settings.howToProcessMultipleDates);
     this.githubClient = new GithubClient(this.settings.githubPersonalAccessToken, this.settings.githubGistId, this.settings.filename);
     this.fileClient = new FileClient(this.app.vault, this.settings.savePath, this.settings.saveFileName, this.settings.saveFileExtension);
     this.tasks = [];

--- a/src/Model/Settings.ts
+++ b/src/Model/Settings.ts
@@ -1,8 +1,14 @@
 export const HOW_TO_PARSE_INTERNAL_LINKS = {
-  DoNotModifyThem: 'Do not modify them',
+  DoNotModifyThem: 'Do not modify them (default)',
   KeepTitle: 'Keep the title',
   PreferTitle: 'Prefer the title',
   RemoveThem: 'Remove them',
+};
+
+export const HOW_TO_PROCESS_MULTIPLE_DATES = {
+  PreferDueDate: 'Prefer due date (default)',
+  PreferStartDate: 'Prefer start date',
+  CreateMultipleEvents: 'Create an event per start/scheduled/due date',
 };
 
 export interface Settings {
@@ -22,6 +28,7 @@ export interface Settings {
   isDebug: boolean;
   ignoreOldTasks: boolean;
   oldTaskInDays: number;
+  howToProcessMultipleDates: string;
 }
 
 export const DEFAULT_SETTINGS: Settings = {
@@ -41,6 +48,7 @@ export const DEFAULT_SETTINGS: Settings = {
   isDebug: false,
   ignoreOldTasks: false,
   oldTaskInDays: 365,
+  howToProcessMultipleDates: HOW_TO_PROCESS_MULTIPLE_DATES.PreferDueDate,
 };
 
 export function settingsWithoutSecrets(settings: Settings): Settings {

--- a/src/ObsidianIcalPlugin.ts
+++ b/src/ObsidianIcalPlugin.ts
@@ -98,6 +98,7 @@ export default class ObsidianIcalPlugin extends Plugin {
 
   async loadSettings() {
     this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
+    await this.saveSettings();
   }
 
   async saveSettings() {

--- a/src/SettingTab.ts
+++ b/src/SettingTab.ts
@@ -8,7 +8,7 @@ import {
   ToggleComponent
 } from 'obsidian';
 import * as path from 'path';
-import { DEFAULT_SETTINGS, HOW_TO_PARSE_INTERNAL_LINKS } from 'src/Model/Settings';
+import { DEFAULT_SETTINGS, HOW_TO_PARSE_INTERNAL_LINKS, HOW_TO_PROCESS_MULTIPLE_DATES } from 'src/Model/Settings';
 import { log } from './Logger';
 import ObsidianIcalPlugin from './ObsidianIcalPlugin';
 
@@ -83,6 +83,20 @@ export class SettingTab extends PluginSettingTab {
             })
         );
     }
+
+    new Setting(containerEl)
+      .setName('Which task date should be used?')
+      .setDesc('A task can have many dates (eg: due, start, scheduled, etc). When multiple dates are encountered in a task, which date do you want to use for the calendar?')
+      .addDropdown((dropdown: DropdownComponent) =>
+        dropdown
+          .addOptions(HOW_TO_PROCESS_MULTIPLE_DATES)
+          .setValue(this.plugin.settings.howToProcessMultipleDates)
+          .onChange(async (value) => {
+            this.plugin.settings.howToProcessMultipleDates = value;
+            await this.plugin.saveSettings();
+            this.display();
+          })
+      );
 
     new Setting(containerEl)
       .setName('Save calendar to GitHub Gist?')


### PR DESCRIPTION
Fixes #30

Tasks can have one or more dates. From either a single raw date in YYYY-MM-DD format, to dates for when a task starts, is scheduled or is due. This setting is to customise which date is chosen when building your iCalendar.

#### Prefer due date (default)

Prefer due date means the following sequence will be followed:

1. If the task has a due date and a start date, they will be the start and end date
1. If the task only has a due date, that will be used
1. If the task only has a start date, that will be used
1. If neither are found, just find any date related to that task

#### Prefer start date

Prefer start date means the following sequence will be followed:

1. If the task only has a start date, that will be used
1. If the task only has a due date, that will be used
1. If neither are found, just find any date related to that task

#### Create an event per start/scheduled/due date

Create an event for each start date, scheduled date and due date associated with a task. This means if your task has all three dates, then three separate events will be created in your calendar.

1. If there is a start date, an event will be created using that date. The summary will be appended with a 🛫.
1. If there is a scheduled date, an event will be created using that date. The summary will be appended with a ⏳.
1. If there is a due date, an event will be created using that date. The summary will be appended with a 📅.
1. If none of the above dates were found, then take any old date that we can find