### PR TITLE
Added an option to select a root folder

### DIFF
--- a/src/Main.ts
+++ b/src/Main.ts
@@ -27,7 +27,8 @@ export class Main {
   }
 
   async start() {
-    const markdownFiles = this.app.vault.getMarkdownFiles();
+    const markdownFiles = this.app.vault.getMarkdownFiles()
+      .filter((file) => file.path.startsWith(settings.rootFolder));
     const taskPromises = [];
 
     log('Performing a scan');

--- a/src/Model/Settings.ts
+++ b/src/Model/Settings.ts
@@ -36,6 +36,7 @@ export interface Settings {
   includeTasksWithTags: string;
   isExcludeTasksWithTags: boolean;
   excludeTasksWithTags: string;
+  rootFolder: string;
 }
 
 export const DEFAULT_SETTINGS: Settings = {
@@ -63,4 +64,5 @@ export const DEFAULT_SETTINGS: Settings = {
   includeTasksWithTags: '#calendar',
   isExcludeTasksWithTags: false,
   excludeTasksWithTags: '#ignore',
+  rootFolder: '',
 };

--- a/src/SettingTab.ts
+++ b/src/SettingTab.ts
@@ -29,6 +29,17 @@ export class SettingTab extends PluginSettingTab {
     containerEl.createEl('p', { cls: 'setting-item-description', text: 'This plugin finds all of the tasks in your vault that contain a date and generates a calendar in iCalendar format. The calendar can be saved to a file and/or saved in a Gist on GitHub so that it can be added to your iCalendar calendar of choice.' });
 
     new Setting(containerEl)
+      .setName('Root folder')
+      .setDesc('Starting folder from which the plugin will start looking for tasks.')
+      .addText((text) =>
+        text
+          .setValue(settings.rootFolder.toString())
+          .onChange(async (folder) => {
+            settings.rootFolder = folder;
+          })
+      );
+
+    new Setting(containerEl)
       .setName('Processing internal links')
       .setDesc('How should [[wikilinks]] and [markdown links](markdown links) be processed if they are encountered in a task?')
       .addDropdown((dropdown: DropdownComponent) =>

--- a/src/SettingsManager.ts
+++ b/src/SettingsManager.ts
@@ -262,6 +262,15 @@ class SettingsManager {
     this.settings.excludeTasksWithTags = excludeTasksWithTags;
     this.saveSettings();
   }
+
+  public get rootFolder(): string {
+    return this.settings.rootFolder;
+  }
+
+  public set rootFolder(rootFolder: string) {
+    this.settings.rootFolder = rootFolder;
+    this.saveSettings();
+  }
 }
 
 export let settings: SettingsManager = SettingsManager.settingsManager;


### PR DESCRIPTION
I followed up on #75 and modified a bit the code to add a "root folder" option into the settings. As for the functionality, I simply used the value of this field to filter the markdown files returned by the vault. 