### PR TITLE
Fix: Replace Buffer with TextEncoder/TextDecoder for mobile comptability

### DIFF
--- a/src/IcalService.ts
+++ b/src/IcalService.ts
@@ -194,10 +194,17 @@ export class IcalService {
     calendar = calendar.replace('~(*BSR_ANYCRLF)\R~', '\r\n');
 
     // Line length should not be longer than 75 characters (https://icalendar.org/iCalendar-RFC-5545/3-1-content-lines.html)
-    //#TODO I can't be bothered implementing this *should* requirement
+    //#TODO I can't be bothered implementing this *should* requirement 
+    
+    // Buffer is not used here because it relies on Node.js-specific APIs like Buffer.from and Buffer.toString,    
+    // which are not available in environments like mobile versions of Obsidian.
+    // Instead, TextEncoder and TextDecoder are used for compatibility.
 
     // Ensure we are UTF-8
-    calendar = Buffer.from(calendar, 'utf8').toString('utf8');
+    const encoder = new TextEncoder();
+    const decoder = new TextDecoder('utf-8');
+    const encoded = encoder.encode(calendar);
+    calendar = decoder.decode(encoded);
 
     return calendar;
   }


### PR DESCRIPTION
- Replaced the use of Buffer with TextEncoder and TextDecoder in the pretty function for **mobile comptability**
- Added comments explaining that Buffer is not compatible with mobile versions of Obsidian due to reliance on Node.js-specific APIs.
- Ensures UTF-8 encoding is maintained without breaking compatibility across different environments.