### PR TITLE
Add link to Obsidian in event description

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,10 @@ You can enter one or more tags. If a task contains any of these tags, then it wi
 
 If you have include tags and exclude tags, then exclude tags take priority.
 
+### Add link to Obsidian in event description
+
+If this is enabled, a link to the file that contains the task will be added to the event description. This is useful for clients such as Thunderbird and Evolution, as they do not support links in the event location.
+
 ### Save calendar to GitHub Gist
 
 Saving to GitHub Gist means you will be given a URL that you can import into your calendar applications.

--- a/src/IcalService.ts
+++ b/src/IcalService.ts
@@ -135,6 +135,7 @@ export class IcalService {
 
     event += '' +
       'SUMMARY:' + prependSummary + task.getSummary() + '\r\n' +
+      (settings.isIncludeLinkInDescription ? 'DESCRIPTION:' + encodeURI(task.getLocation()) + '\r\n' : '') +
       'LOCATION:ALTREP="' + encodeURI(task.getLocation()) + '":' + encodeURI(task.getLocation()) + '\r\n' +
       'END:VEVENT\r\n';
 
@@ -184,6 +185,11 @@ export class IcalService {
       case TaskStatus.Cancelled:
         toDo += 'STATUS:CANCELLED\r\n';
         break;
+    }
+
+
+    if (settings.isIncludeLinkInDescription) {
+      toDo += 'DESCRIPTION:' + encodeURI(task.getLocation()) + '\r\n';
     }
 
     toDo += 'END:VTODO\r\n';

--- a/src/Model/Settings.ts
+++ b/src/Model/Settings.ts
@@ -43,6 +43,7 @@ export interface Settings {
   isExcludeTasksWithTags: boolean;
   excludeTasksWithTags: string;
   rootPath: string;
+  isIncludeLinkInDescription: boolean;
 }
 
 export const DEFAULT_SETTINGS: Settings = {
@@ -71,4 +72,5 @@ export const DEFAULT_SETTINGS: Settings = {
   isExcludeTasksWithTags: false,
   excludeTasksWithTags: '#ignore',
   rootPath: '/',
+  isIncludeLinkInDescription: false,
 };

--- a/src/SettingTab.ts
+++ b/src/SettingTab.ts
@@ -272,6 +272,18 @@ export class SettingTab extends PluginSettingTab {
         );
     }
 
+    new Setting(containerEl)
+      .setName('Add link to Obsidian in event description')
+      .setDesc('Include a link to open the task in Obsidian in the event description. This is useful for clients such as Thunderbird or Evolution.')
+      .addToggle((toggle: ToggleComponent) =>
+        toggle
+          .setValue(settings.isIncludeLinkInDescription)
+          .onChange(async (value) => {
+            settings.isIncludeLinkInDescription = value;
+            this.display();
+          })
+      );
+
     if (settings.isSaveToGistEnabled) {
       containerEl.createEl('h1', { text: 'Save calendar to GitHub Gist' });
 

--- a/src/SettingsManager.ts
+++ b/src/SettingsManager.ts
@@ -271,6 +271,15 @@ class SettingsManager {
     this.settings.rootPath = rootPath;
     this.saveSettings();
   }
+
+  public get isIncludeLinkInDescription(): boolean {
+    return this.settings.isIncludeLinkInDescription;
+  }
+
+  public set isIncludeLinkInDescription(isIncludeLinkInDescription: boolean) {
+    this.settings.isIncludeLinkInDescription = isIncludeLinkInDescription;
+    this.saveSettings();
+  }
 }
 
 export let settings: SettingsManager = SettingsManager.settingsManager;


### PR DESCRIPTION
Add setting that can add a link to Obsidian in the event description. Fixes #76.