### PR TITLE
Show saved value in target directory dropdown

### DIFF
--- a/src/SettingTab.ts
+++ b/src/SettingTab.ts
@@ -157,6 +157,7 @@ export class SettingTab extends PluginSettingTab {
         });
 
         dropdown
+          .setValue(settings.rootPath)
           .onChange(async (value) => {
             value = normalizePath(value);
             settings.rootPath = value;


### PR DESCRIPTION
The Target directory dropdown in settings was missing a `setValue` call, so every render reset the visible selection to the first alphabetical directory even though the saved `rootPath` was correct.

Call `dropdown.setValue(settings.rootPath)` after the options are populated.

Closes #129