### PR TITLE
Rename duplicate Save Destinations heading

### DIFF
--- a/src/SettingTab.ts
+++ b/src/SettingTab.ts
@@ -567,7 +567,9 @@ export class SettingTab extends PluginSettingTab {
           })
       );
 
-    new Setting(containerEl).setName('Save Destinations').setHeading();
+    if (settings.isSaveToGistEnabled || settings.isSaveToFileEnabled || settings.isSaveToWebEnabled) {
+      new Setting(containerEl).setName('Save Destination Details').setHeading();
+    }
 
     if (settings.isSaveToGistEnabled) {
       new Setting(containerEl).setName('GitHub Gist Settings').setHeading();


### PR DESCRIPTION
## Summary

- Rename the second `Save Destinations` heading to `Save Destination Details` so it no longer collides with the heading above the enable toggles.
- Only render the new heading when at least one save destination (Gist, File, or Web) is enabled, so it never appears as an empty section.

The reporter's core complaint — vault not appearing on obsidian-ical.com — is server-side and out of scope for the plugin; this PR addresses only the visual duplication they also noted.

Refs #141