### PR TITLE
Drop UTC Z suffix from timed event format (#138)

### DIFF
--- a/src/IcalService.ts
+++ b/src/IcalService.ts
@@ -63,8 +63,8 @@ export class IcalService {
           } else if (task.hasA(TaskDateName.Due)) {
             event += 'DTSTART:' + task.getDate(TaskDateName.Due, 'YYYYMMDD') + '\r\n';
           } else if (task.hasA(TaskDateName.TimeStart) && task.hasA(TaskDateName.TimeEnd)) {
-            event += 'DTSTART:' + task.getDate(TaskDateName.TimeStart, 'YYYYMMDD[T]HHmmss[Z]') + '\r\n';
-            event += 'DTEND:' + task.getDate(TaskDateName.TimeEnd, 'YYYYMMDD[T]HHmmss[Z]') + '\r\n';
+            event += 'DTSTART:' + task.getDate(TaskDateName.TimeStart, 'YYYYMMDD[T]HHmmss') + '\r\n';
+            event += 'DTEND:' + task.getDate(TaskDateName.TimeEnd, 'YYYYMMDD[T]HHmmss') + '\r\n';
           } else {
             event += 'DTSTART:' + task.getDate(null, 'YYYYMMDD') + '\r\n';
           }
@@ -115,8 +115,8 @@ export class IcalService {
             event += '' +
               'DTSTART:' + task.getDate(TaskDateName.Start, 'YYYYMMDD') + '\r\n';
           } else if (task.hasA(TaskDateName.TimeStart) && task.hasA(TaskDateName.TimeEnd)) {
-            event += 'DTSTART:' + task.getDate(TaskDateName.TimeStart, 'YYYYMMDD[T]HHmmss[Z]') + '\r\n';
-            event += 'DTEND:' + task.getDate(TaskDateName.TimeEnd, 'YYYYMMDD[T]HHmmss[Z]') + '\r\n';
+            event += 'DTSTART:' + task.getDate(TaskDateName.TimeStart, 'YYYYMMDD[T]HHmmss') + '\r\n';
+            event += 'DTEND:' + task.getDate(TaskDateName.TimeEnd, 'YYYYMMDD[T]HHmmss') + '\r\n';
           } else {
             event += '' +
               'DTSTART:' + task.getDate(null, 'YYYYMMDD') + '\r\n';


### PR DESCRIPTION
Closes #138.

## What

Drop the literal `Z` from the `DTSTART`/`DTEND` format string used for Day Planner time ranges in `IcalService.ts`. Format changes from `YYYYMMDD[T]HHmmss[Z]` to `YYYYMMDD[T]HHmmss` in both the `PreferStartDate` and `PreferDueDate` branches.

## Why

Per RFC 5545, a trailing `Z` on a `DATE-TIME` value declares the time as UTC. But `Task.getDate()` intentionally emits **local** wall-clock time (see the comment at `src/Model/Task.ts:63-69`). The result was that compliant calendars (Apple Calendar, Google Calendar, Outlook) read `20240301T080000Z` as 08:00 UTC and shifted it to the viewer's local timezone — so a task entered as `08:00-10:00` in NYC was displayed at `03:00-05:00`.

Removing the `Z` produces a floating-time `DATE-TIME` (RFC 5545 §3.3.5 form 1), which is displayed as-is in the viewer's local timezone. This matches the user expectation for Day Planner tasks (\"this event is at 08:00 wherever I am\").

## ⚠️ Behaviour change — please read

If you previously **adapted** to the broken behaviour by entering shifted times (e.g. you live in NYC and typed `13:00-15:00` to make the task display at `08:00-10:00`), this fix will un-do that compensation and your displayed times will move. **You will need to re-enter your tasks with the unshifted (intended) times.**

If you live in UTC, or you only use all-day tasks (no time ranges), or you only use Day Planner via the standard daily-note workflow without ever noticing a shift, you will see **no change** in behaviour.

## Scope of affected code

The `Z` suffix only appeared on four lines in `src/IcalService.ts`, all in the `task.hasA(TaskDateName.TimeStart) && task.hasA(TaskDateName.TimeEnd)` branch. That branch fires only when a Day Planner time range is parsed and there is **no** emoji `🛫`/`📅` date on the same line — i.e. when the date comes from the daily-note filename. All-day events (the majority of usage) take a different code path and are untouched.

## Test plan

- [x] `bun run build` (tsc -noEmit + esbuild production) — passes
- [x] Manual: open a daily note containing a Day Planner task like `- [ ] 08:00-10:00 Standup`, regenerate the calendar, open the `.ics` in Apple Calendar / Google Calendar / Outlook, confirm the event displays at 08:00 local time (not shifted).
- [x] Manual: confirm all-day tasks (with `📅 YYYY-MM-DD` only) are unchanged.

## Release-notes note

Please surface the **Behaviour change** section prominently in release notes so any non-UTC users who adapted to the bug have a clear heads-up to re-enter their data.