### PR TITLE
Guard against undefined task lines during scan

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,2 @@
+[test]
+root = "./test"

--- a/src/Model/Task.ts
+++ b/src/Model/Task.ts
@@ -87,6 +87,10 @@ export class Task {
 }
 
 export function createTaskFromLine(line: string, fileUri: string, dateOverride: Date|null): Task|null {
+  if (!line) {
+    return null;
+  }
+
   const taskRegExp = /(\*|-)\s*(?<taskStatus>\[.?])\s*(?<summary>.*)\s*/gi;
   const dateRegExp = /\b(?<year>\d{4})-(?<month>\d{2})-(?<day>\d{1,2})\b/gi;
 

--- a/src/TaskFinder.ts
+++ b/src/TaskFinder.ts
@@ -28,6 +28,11 @@ export class TaskFinder {
           'markdownLine': lines[markdownLineNumber],
         };
       })
+      // Obsidian's metadata cache can lag behind cachedRead, so listItemsCache may reference
+      // line indices that no longer exist in the file. Drop those before they hit createTaskFromLine.
+      .filter((lineAndHeading) => {
+        return typeof lineAndHeading.markdownLine === 'string' && lineAndHeading.markdownLine.length > 0;
+      })
       // Create a Task from the line
       .map((lineAndHeading) => {
         // If the Day Planner plugin format is enabled and the line contains at least one time,

--- a/src/__tests__/Task.test.ts
+++ b/src/__tests__/Task.test.ts
@@ -1,0 +1,20 @@
+jest.mock('obsidian', () => ({
+  moment: jest.fn(),
+  Plugin: class {},
+}));
+
+import { createTaskFromLine } from '../Model/Task';
+
+describe('createTaskFromLine', () => {
+  it('returns null when line is undefined', () => {
+    expect(createTaskFromLine(undefined as unknown as string, 'obsidian://open?vault=v&file=f', null)).toBeNull();
+  });
+
+  it('returns null when line is null', () => {
+    expect(createTaskFromLine(null as unknown as string, 'obsidian://open?vault=v&file=f', null)).toBeNull();
+  });
+
+  it('returns null when line is an empty string', () => {
+    expect(createTaskFromLine('', 'obsidian://open?vault=v&file=f', null)).toBeNull();
+  });
+});


### PR DESCRIPTION
Both reporters in #98 and #90 hit `Cannot read properties of undefined (reading 'matchAll' / 'includes')` during the periodic scan. Root cause is a race between Obsidian's metadata cache and `vault.cachedRead`: `listItemsCache` can hold a line index that's beyond the freshly-read file contents, so `lines[markdownLineNumber]` returns `undefined` and the subsequent regex / tag check explodes.

## Changes

- `src/TaskFinder.ts` — filter out entries with a falsy `markdownLine` before they reach `createTaskFromLine`.
- `src/Model/Task.ts` — defensive early-return of `null` from `createTaskFromLine` if `line` is falsy, in case anything else ever calls it with bad input.
- `src/__tests__/Task.test.ts` — Jest cases for `undefined` / `null` / empty-string input.
- `bunfig.toml` — scopes `bun test` to `./test`, matching the documented intent (bun runs the legacy iCal tests, `bun run test` runs Jest). The new Jest test imports `Task.ts` which imports from `obsidian`; without this, bun's native runner would try (and fail) to resolve `obsidian` for that file.

Closes #98
Closes #90