### PR TITLE
Add isIncludeLocation setting to suppress LOCATION/ALTREP

### DIFF
--- a/src/IcalService.ts
+++ b/src/IcalService.ts
@@ -133,7 +133,7 @@ export class IcalService {
     event += '' +
       'SUMMARY:' + prependSummary + task.getSummary() + '\r\n' +
       (settings.isIncludeLinkInDescription ? 'DESCRIPTION:' + encodeURI(task.getLocation()) + '\r\n' : '') +
-      'LOCATION:ALTREP="' + encodeURI(task.getLocation()) + '":' + encodeURI(task.getLocation()) + '\r\n' +
+      (settings.isIncludeLocation ? 'LOCATION:ALTREP="' + encodeURI(task.getLocation()) + '":' + encodeURI(task.getLocation()) + '\r\n' : '') +
       'END:VEVENT\r\n';
 
     return event;
@@ -159,7 +159,7 @@ export class IcalService {
       'SUMMARY:' + task.getSummary() + '\r\n' +
       // If a task does not have a date, do not include the DTSTAMP property
       (task.hasAnyDate() ? 'DTSTAMP:' + task.getDate(null, 'YYYYMMDDTHHmmss') + '\r\n' : '') +
-      'LOCATION:ALTREP="' + encodeURI(task.getLocation()) + '":' + encodeURI(task.getLocation()) + '\r\n';
+      (settings.isIncludeLocation ? 'LOCATION:ALTREP="' + encodeURI(task.getLocation()) + '":' + encodeURI(task.getLocation()) + '\r\n' : '');
 
     if (task.hasA(TaskDateName.Due)) {
       toDo += 'DUE;VALUE=DATE:' + task.getDate(TaskDateName.Due, 'YYYYMMDD') + '\r\n';

--- a/src/Model/Settings.ts
+++ b/src/Model/Settings.ts
@@ -45,6 +45,7 @@ export interface Settings {
   excludeTasksWithTags: string;
   rootPath: string;
   isIncludeLinkInDescription: boolean;
+  isIncludeLocation: boolean;
   secretKey: string;
 }
 
@@ -76,5 +77,6 @@ export const DEFAULT_SETTINGS: Settings = {
   excludeTasksWithTags: '#ignore',
   rootPath: '/',
   isIncludeLinkInDescription: false,
+  isIncludeLocation: true,
   secretKey: '',
 };

--- a/src/SettingTab.ts
+++ b/src/SettingTab.ts
@@ -567,6 +567,18 @@ export class SettingTab extends PluginSettingTab {
           })
       );
 
+    new Setting(containerEl)
+      .setName('Include link to Obsidian as event location')
+      .setDesc('Include a link to open the task in Obsidian as the event location. Disable this if your calendar client treats the LOCATION field as a physical address.')
+      .addToggle((toggle: ToggleComponent) =>
+        toggle
+          .setValue(settings.isIncludeLocation)
+          .onChange(async (value) => {
+            settings.isIncludeLocation = value;
+            this.display();
+          })
+      );
+
     if (settings.isSaveToGistEnabled || settings.isSaveToFileEnabled || settings.isSaveToWebEnabled) {
       new Setting(containerEl).setName('Save Destination Details').setHeading();
     }

--- a/src/SettingsManager.ts
+++ b/src/SettingsManager.ts
@@ -281,6 +281,15 @@ class SettingsManager {
     void this.saveSettings();
   }
 
+  public get isIncludeLocation(): boolean {
+    return this.settings.isIncludeLocation;
+  }
+
+  public set isIncludeLocation(isIncludeLocation: boolean) {
+    this.settings.isIncludeLocation = isIncludeLocation;
+    void this.saveSettings();
+  }
+
   public get secretKey(): string {
     return this.settings.secretKey;
   }

--- a/src/__tests__/IcalService.test.ts
+++ b/src/__tests__/IcalService.test.ts
@@ -1,0 +1,88 @@
+(global as any).window = {
+  crypto: {
+    randomUUID: () => '00000000-0000-0000-0000-000000000000',
+  },
+};
+
+jest.mock('obsidian', () => ({
+  moment: (input: Date | string) => {
+    const d = input instanceof Date ? input : new Date(input);
+    return {
+      format: (fmt: string) => {
+        const pad = (n: number, w = 2) => String(n).padStart(w, '0');
+        const yyyy = d.getFullYear();
+        const mm = pad(d.getMonth() + 1);
+        const dd = pad(d.getDate());
+        const hh = pad(d.getHours());
+        const mi = pad(d.getMinutes());
+        const ss = pad(d.getSeconds());
+        return fmt
+          .replace('YYYY', String(yyyy))
+          .replace('MM', mm)
+          .replace('DD', dd)
+          .replace('[T]', 'T')
+          .replace('HH', hh)
+          .replace('mm', mi)
+          .replace('ss', ss);
+      },
+    };
+  },
+  Plugin: class {},
+}));
+
+const mockSettings = {
+  includeEventsOrTodos: 'EventsOnly',
+  howToProcessMultipleDates: 'PreferDueDate',
+  isIncludeLinkInDescription: false,
+  isIncludeLocation: true,
+  isOnlyTasksWithoutDatesAreTodos: true,
+};
+
+jest.mock('../SettingsManager', () => ({
+  settings: mockSettings,
+}));
+
+import { IcalService } from '../IcalService';
+import { Task } from '../Model/Task';
+import { TaskDateName } from '../Model/TaskDate';
+import { TaskStatus } from '../Model/TaskStatus';
+
+function buildTaskWithDueDate(): Task {
+  const dueDate = new Date(2026, 4, 15);
+  return new Task(
+    TaskStatus.ToDo,
+    [{ name: TaskDateName.Due, date: dueDate, isDateOnly: true } as any],
+    'Sample task',
+    'obsidian://open?vault=v&file=f',
+  );
+}
+
+describe('IcalService location toggle', () => {
+  beforeEach(() => {
+    mockSettings.isIncludeLocation = true;
+    mockSettings.includeEventsOrTodos = 'EventsOnly';
+    mockSettings.howToProcessMultipleDates = 'PreferDueDate';
+    mockSettings.isIncludeLinkInDescription = false;
+  });
+
+  it('includes LOCATION line in VEVENT when isIncludeLocation is true', () => {
+    mockSettings.isIncludeLocation = true;
+    const ical = new IcalService().getCalendar([buildTaskWithDueDate()]);
+    expect(ical).toContain('LOCATION:ALTREP=');
+  });
+
+  it('omits LOCATION line in VEVENT when isIncludeLocation is false', () => {
+    mockSettings.isIncludeLocation = false;
+    const ical = new IcalService().getCalendar([buildTaskWithDueDate()]);
+    expect(ical).not.toContain('LOCATION:');
+  });
+
+  it('omits LOCATION line in VTODO when isIncludeLocation is false', () => {
+    mockSettings.isIncludeLocation = false;
+    mockSettings.includeEventsOrTodos = 'TodosOnly';
+    mockSettings.isOnlyTasksWithoutDatesAreTodos = false;
+    const ical = new IcalService().getCalendar([buildTaskWithDueDate()]);
+    expect(ical).toContain('BEGIN:VTODO');
+    expect(ical).not.toContain('LOCATION:');
+  });
+});

--- a/src/__tests__/Settings.test.ts
+++ b/src/__tests__/Settings.test.ts
@@ -36,6 +36,7 @@ describe('Settings', () => {
       expect(DEFAULT_SETTINGS).toHaveProperty('excludeTasksWithTags');
       expect(DEFAULT_SETTINGS).toHaveProperty('rootPath');
       expect(DEFAULT_SETTINGS).toHaveProperty('isIncludeLinkInDescription');
+      expect(DEFAULT_SETTINGS).toHaveProperty('isIncludeLocation');
       expect(DEFAULT_SETTINGS).toHaveProperty('secretKey');
     });
 
@@ -61,6 +62,7 @@ describe('Settings', () => {
       expect(DEFAULT_SETTINGS.excludeTasksWithTags).toBe('#ignore');
       expect(DEFAULT_SETTINGS.rootPath).toBe('/');
       expect(DEFAULT_SETTINGS.isIncludeLinkInDescription).toBe(false);
+      expect(DEFAULT_SETTINGS.isIncludeLocation).toBe(true);
     });
 
     it('should have empty strings for sensitive data by default', () => {


### PR DESCRIPTION
Adds a new toggle, **Include link to Obsidian as event location**, that controls whether the generated calendar emits `LOCATION:ALTREP=...` lines on VEVENT and VTODO entries.

Defaults to `true` (current behavior preserved). Reporters whose calendar clients treat `LOCATION` as a physical address can disable it.

## Touch-points

- `src/Model/Settings.ts` — interface field + default
- `src/SettingsManager.ts` — getter/setter
- `src/SettingTab.ts` — toggle alongside the existing "Add link to Obsidian in event description" toggle
- `src/IcalService.ts` — wraps both VEVENT (line ~136) and VTODO (line ~162) `LOCATION` writes
- Jest tests — Settings default + IcalService VEVENT/VTODO suppression

Closes #145