### PR TITLE
Parse inline time ranges in non-Day-Planner tasks

### DIFF
--- a/src/IcalService.ts
+++ b/src/IcalService.ts
@@ -58,13 +58,14 @@ export class IcalService {
         // If a start date does not exist, take the due date
         // If a due date does not exist, take any old date that we can find
         case 'PreferStartDate':
-          if (task.hasA(TaskDateName.Start)) {
+          // An inline time range anchors to the task's date, so prefer it over an all-day emit.
+          if (task.hasA(TaskDateName.TimeStart) && task.hasA(TaskDateName.TimeEnd)) {
+            event += 'DTSTART:' + task.getDate(TaskDateName.TimeStart, 'YYYYMMDD[T]HHmmss') + '\r\n';
+            event += 'DTEND:' + task.getDate(TaskDateName.TimeEnd, 'YYYYMMDD[T]HHmmss') + '\r\n';
+          } else if (task.hasA(TaskDateName.Start)) {
             event += 'DTSTART:' + task.getDate(TaskDateName.Start, 'YYYYMMDD') + '\r\n';
           } else if (task.hasA(TaskDateName.Due)) {
             event += 'DTSTART:' + task.getDate(TaskDateName.Due, 'YYYYMMDD') + '\r\n';
-          } else if (task.hasA(TaskDateName.TimeStart) && task.hasA(TaskDateName.TimeEnd)) {
-            event += 'DTSTART:' + task.getDate(TaskDateName.TimeStart, 'YYYYMMDD[T]HHmmss') + '\r\n';
-            event += 'DTEND:' + task.getDate(TaskDateName.TimeEnd, 'YYYYMMDD[T]HHmmss') + '\r\n';
           } else {
             event += 'DTSTART:' + task.getDate(null, 'YYYYMMDD') + '\r\n';
           }
@@ -104,7 +105,11 @@ export class IcalService {
         // If a start date does not exist, take any old date that we can find
         case 'PreferDueDate':
         default:
-          if (task.hasA(TaskDateName.Start) && task.hasA(TaskDateName.Due)) {
+          // An inline time range anchors to the task's date, so prefer it over an all-day emit.
+          if (task.hasA(TaskDateName.TimeStart) && task.hasA(TaskDateName.TimeEnd)) {
+            event += 'DTSTART:' + task.getDate(TaskDateName.TimeStart, 'YYYYMMDD[T]HHmmss') + '\r\n';
+            event += 'DTEND:' + task.getDate(TaskDateName.TimeEnd, 'YYYYMMDD[T]HHmmss') + '\r\n';
+          } else if (task.hasA(TaskDateName.Start) && task.hasA(TaskDateName.Due)) {
             event += '' +
               'DTSTART:' + task.getDate(TaskDateName.Start, 'YYYYMMDDTHHmmss') + '\r\n' +
               'DTEND:' + task.getDate(TaskDateName.Due, 'YYYYMMDDTHHmmss') + '\r\n';
@@ -114,9 +119,6 @@ export class IcalService {
           } else if (task.hasA(TaskDateName.Start)) {
             event += '' +
               'DTSTART:' + task.getDate(TaskDateName.Start, 'YYYYMMDD') + '\r\n';
-          } else if (task.hasA(TaskDateName.TimeStart) && task.hasA(TaskDateName.TimeEnd)) {
-            event += 'DTSTART:' + task.getDate(TaskDateName.TimeStart, 'YYYYMMDD[T]HHmmss') + '\r\n';
-            event += 'DTEND:' + task.getDate(TaskDateName.TimeEnd, 'YYYYMMDD[T]HHmmss') + '\r\n';
           } else {
             event += '' +
               'DTSTART:' + task.getDate(null, 'YYYYMMDD') + '\r\n';

--- a/src/Model/TaskDate.ts
+++ b/src/Model/TaskDate.ts
@@ -30,9 +30,13 @@ const TaskDateEmojiMap: Record<TaskDateName, string> = {
   [TaskDateName.TimeEnd]: '',
 };
 
+// Multiple TaskDateNames map to '' (Unknown, TimeStart, TimeEnd); skip those so the
+// reverse lookup of an absent emoji falls through to the `?? Unknown` default below.
 const EmojiToTaskDateNameMap: Record<string, TaskDateName> = Object.entries(TaskDateEmojiMap).reduce(
   (acc, [key, emoji]) => {
-    acc[emoji] = key as TaskDateName;
+    if (emoji !== '') {
+      acc[emoji] = key as TaskDateName;
+    }
     return acc;
   },
   {} as Record<string, TaskDateName>
@@ -85,41 +89,27 @@ function convertDataviewToEmoji(markdown: string): string {
   return markdown;
 }
 
+// Day Planner mode: the line sits under a date heading, so we accept loose formats
+// including a bare hour ("3pm", "09") as the first numeric token.
+const dayPlannerTimeRegExp = /\b(\d{1,2}(?::\d{2})?(?::\d{2})?\s*[ap]m|\d{1,2}(?::\d{2})?(?::\d{2})?)(?:\s*-\s*(\d{1,2}(?::\d{2})?(?::\d{2})?\s*[ap]m|\d{1,2}(?::\d{2})?(?::\d{2})?))?\b/i;
+
+// Inline mode: require HH:MM or H[H][AM/PM] so plain numbers in descriptions don't
+// match. The lookbehind blocks digits inside dates like "2026-04-20".
+const inlineTimeRegExp = /\b(?<!\d{4}-(?:\d{2}-)?)(\d{1,2}:\d{2}(?::\d{2})?(?:\s*[ap]m)?|\d{1,2}\s*[ap]m)(?:\s*-\s*(\d{1,2}:\d{2}(?::\d{2})?(?:\s*[ap]m)?|\d{1,2}\s*[ap]m))?\b/i;
+
 export function getTaskDatesFromMarkdown(markdown: string, dateOverride: Date|null): TaskDate[] {
   // Convert Dataview Format to Emoji Format
   markdown = convertDataviewToEmoji(markdown);
 
   // If we have an override date, then just use that instead of trying to derive them
   if (dateOverride !== null) {
-    const timeRegExp = /\b(\d{1,2}(?::\d{2})?(?::\d{2})?\s*[ap]m|\d{1,2}(?::\d{2})?(?::\d{2})?)(?:\s*-\s*(\d{1,2}(?::\d{2})?(?::\d{2})?\s*[ap]m|\d{1,2}(?::\d{2})?(?::\d{2})?))?\b/i;
-    // const timeRegExp = /\b((?<!\d{4}-\d{2}-)\d{1,2}:(\d{2})(?::\d{2})?\s*(?:[ap][m])?|(?<!\d{4}-\d{2}-)\d{1,2}\s*[ap][m])\b/gi;
-    const match = markdown.match(timeRegExp);
-
-    if (!match) {
-      return [];
-    }
-
-    let timeStartString = match[1];
-    let timeEndString = match[2]; // The second time, if present
-
-    if (!timeEndString) {
-      // If the second time is not present, calculate it
-      timeEndString = calculateEndTime(timeStartString);
-    }
-
-    const timeStart = createTimeDate(dateOverride, timeStartString);
-    const timeEnd = createTimeDate(dateOverride, timeEndString);
-
-    return [
-      new TaskDate(timeStart, TaskDateName.TimeStart),
-      new TaskDate(timeEnd, TaskDateName.TimeEnd),
-    ];
+    return extractTimeRange(markdown, dateOverride, dayPlannerTimeRegExp);
   }
 
   const dateRegExp = /(?<emoji>➕|⏳|🛫|📅|✅)?\s?(?<year>\d{4})-(?<month>\d{2})-(?<day>\d{1,2})\b/gi;
   const dateMatches = [...markdown.matchAll(dateRegExp)];
 
-  const taskDates = dateMatches
+  const taskDates: TaskDate[] = dateMatches
     .filter((dateMatch) => {
       // Validate (emoji is optional)
       return  dateMatch?.groups?.day &&
@@ -137,7 +127,30 @@ export function getTaskDatesFromMarkdown(markdown: string, dateOverride: Date|nu
       return new TaskDate(date, taskDateName);
     });
 
+  if (taskDates.length > 0) {
+    taskDates.push(...extractTimeRange(markdown, taskDates[0].date, inlineTimeRegExp));
+  }
+
   return taskDates;
+}
+
+function extractTimeRange(markdown: string, baseDate: Date, regExp: RegExp): TaskDate[] {
+  const match = markdown.match(regExp);
+
+  if (!match) {
+    return [];
+  }
+
+  const timeStartString = match[1];
+  const timeEndString = match[2] ?? calculateEndTime(timeStartString);
+
+  const timeStart = createTimeDate(baseDate, timeStartString);
+  const timeEnd = createTimeDate(baseDate, timeEndString);
+
+  return [
+    new TaskDate(timeStart, TaskDateName.TimeStart),
+    new TaskDate(timeEnd, TaskDateName.TimeEnd),
+  ];
 }
 
 function calculateEndTime(startTime: string): string {

--- a/src/Model/TaskSummary.ts
+++ b/src/Model/TaskSummary.ts
@@ -33,6 +33,11 @@ export function getSummaryFromMarkdown(markdown: string, howToParseInternalLinks
   // Remove Dataview dates
   markdown = removeDataviewDates(markdown);
 
+  // Strip inline time ranges (e.g. "17:00-19:00") only when a date is also present,
+  // since TaskDate has anchored that time to the date and produced TimeStart/TimeEnd.
+  // Must run before removeDates so the date is still visible for the check.
+  markdown = removeTimeRanges(markdown);
+
   // Remove any leftover dates
   markdown = removeDates(markdown);
 
@@ -109,6 +114,15 @@ function removeDates(markdown: string): string {
   markdown = markdown.replace(regExp, '');
 
   return markdown;
+}
+
+function removeTimeRanges(markdown: string): string {
+  if (!/\d{4}-\d{2}-\d{1,2}/.test(markdown)) {
+    return markdown;
+  }
+
+  const regExp = /\s*\b(?<!\d{4}-(?:\d{2}-)?)(?:\d{1,2}:\d{2}(?::\d{2})?(?:\s*[ap]m)?|\d{1,2}\s*[ap]m)(?:\s*-\s*(?:\d{1,2}:\d{2}(?::\d{2})?(?:\s*[ap]m)?|\d{1,2}\s*[ap]m))?\b\s*/gi;
+  return markdown.replace(regExp, ' ');
 }
 
 function trimWhitespace(markdown: string): string {

--- a/src/__tests__/InlineTimeRange.test.ts
+++ b/src/__tests__/InlineTimeRange.test.ts
@@ -1,0 +1,123 @@
+(global as any).window = {
+  crypto: {
+    randomUUID: () => '00000000-0000-0000-0000-000000000000',
+  },
+};
+
+jest.mock('obsidian', () => ({
+  moment: (input: Date | string) => {
+    const d = input instanceof Date ? input : new Date(input);
+    return {
+      format: (fmt: string) => {
+        const pad = (n: number, w = 2) => String(n).padStart(w, '0');
+        const yyyy = d.getFullYear();
+        const mm = pad(d.getMonth() + 1);
+        const dd = pad(d.getDate());
+        const hh = pad(d.getHours());
+        const mi = pad(d.getMinutes());
+        const ss = pad(d.getSeconds());
+        return fmt
+          .replace('YYYY', String(yyyy))
+          .replace('MM', mm)
+          .replace('DD', dd)
+          .replace('[T]', 'T')
+          .replace('HH', hh)
+          .replace('mm', mi)
+          .replace('ss', ss);
+      },
+    };
+  },
+  Plugin: class {},
+}));
+
+const mockSettings = {
+  includeEventsOrTodos: 'EventsOnly',
+  howToProcessMultipleDates: 'PreferDueDate',
+  isIncludeLinkInDescription: false,
+  isIncludeLocation: false,
+  isOnlyTasksWithoutDatesAreTodos: true,
+  ignoreCompletedTasks: false,
+  ignoreOldTasks: false,
+  howToParseInternalLinks: 'DoNotModifyThem',
+};
+
+jest.mock('../SettingsManager', () => ({
+  settings: mockSettings,
+}));
+
+import { IcalService } from '../IcalService';
+import { createTaskFromLine } from '../Model/Task';
+
+function ical(line: string): string {
+  const task = createTaskFromLine(line, 'obsidian://open?vault=v&file=f', null);
+  if (task === null) throw new Error('expected task, got null');
+  return new IcalService().getCalendar([task]);
+}
+
+describe('Inline time range parsing', () => {
+  it('parses `- [ ] foo 2026-04-20 17:00-19:00` (no emoji)', () => {
+    const out = ical('- [ ] foo 2026-04-20 17:00-19:00');
+    expect(out).toContain('DTSTART:20260420T170000');
+    expect(out).toContain('DTEND:20260420T190000');
+    expect(out).not.toMatch(/DTSTART:20260420\r\n/);
+    expect(out).not.toContain('Z\r\n');
+    expect(out).toContain('SUMMARY:🔲 foo\r\n');
+    expect(out).not.toContain('17:00');
+    expect(out).not.toContain('19:00');
+  });
+
+  it('parses `- [ ] foo 09:45-10:30 ⏳ 2025-06-13`', () => {
+    const out = ical('- [ ] foo 09:45-10:30 ⏳ 2025-06-13');
+    expect(out).toContain('DTSTART:20250613T094500');
+    expect(out).toContain('DTEND:20250613T103000');
+    expect(out).toContain('SUMMARY:🔲 foo\r\n');
+    expect(out).not.toContain('09:45');
+    expect(out).not.toContain('10:30');
+  });
+
+  it('parses `- [ ] foo 9:30 - 10:30 ⏳ 2024-07-31` (spaces around dash, single-digit hour)', () => {
+    const out = ical('- [ ] foo 9:30 - 10:30 ⏳ 2024-07-31');
+    expect(out).toContain('DTSTART:20240731T093000');
+    expect(out).toContain('DTEND:20240731T103000');
+    expect(out).toContain('SUMMARY:🔲 foo\r\n');
+    expect(out).not.toContain('9:30');
+    expect(out).not.toContain('10:30');
+  });
+
+  it('parses `- [ ] Call client 12:30-13:00 📅 2025-07-29` (#120 case)', () => {
+    const out = ical('- [ ] Call client 12:30-13:00 📅 2025-07-29');
+    expect(out).toContain('DTSTART:20250729T123000');
+    expect(out).toContain('DTEND:20250729T130000');
+    expect(out).toContain('SUMMARY:🔲 Call client\r\n');
+    expect(out).not.toContain('12:30');
+    expect(out).not.toContain('13:00');
+  });
+
+  it('does not mistake digits inside the date for a time', () => {
+    // Without the lookbehind, "04-20" inside "2026-04-20" would match as a time range.
+    const out = ical('- [ ] foo 2026-04-20 17:00-19:00');
+    expect(out).not.toContain('DTSTART:20260420T040000');
+    expect(out).not.toContain('DTSTART:20260420T200000');
+  });
+
+  it('does not match plain numbers in descriptions', () => {
+    // "Buy 3 apples" — no time, only the date. Should be an all-day event.
+    const out = ical('- [ ] Buy 3 apples 📅 2026-04-20');
+    expect(out).toContain('DTSTART:20260420\r\n');
+    expect(out).not.toMatch(/DTSTART:20260420T\d{6}/);
+    expect(out).toContain('SUMMARY:🔲 Buy 3 apples\r\n');
+  });
+
+  it('preserves time text in summary when no date is present (no event anyway)', () => {
+    mockSettings.includeEventsOrTodos = 'EventsAndTodos';
+    mockSettings.isOnlyTasksWithoutDatesAreTodos = true;
+    try {
+      const out = ical('- [ ] reminder 17:00');
+      // No date → becomes a VTODO. Time stays in the summary because we can't anchor it.
+      expect(out).toContain('SUMMARY:🔲 reminder 17:00\r\n');
+    } finally {
+      mockSettings.includeEventsOrTodos = 'EventsOnly';
+      mockSettings.isOnlyTasksWithoutDatesAreTodos = true;
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Inline tasks like `- [ ] foo 2026-04-20 17:00-19:00` previously produced all-day events with the time left as plain text in the SUMMARY. The time was only being parsed in Day Planner mode (when a date heading override was supplied). This PR extracts time ranges from inline tasks too.

## Changes

- **`src/Model/TaskDate.ts`**
  - When `dateOverride === null`, run a time-range regex after the date regex and append `TimeStart`/`TimeEnd` anchored to the first parsed date.
  - New `inlineTimeRegExp` is stricter than the Day Planner regex (requires `HH:MM` or `H[H][AM/PM]`) so plain numbers in descriptions don't match, and uses a lookbehind to skip digits inside dates like `2026-04-20`.
  - Fix `EmojiToTaskDateNameMap` reverse-map collision: `Unknown`, `TimeStart`, `TimeEnd` all map to `''`, and the last `Object.entries` write won. Result: emoji-less dates were silently named `TimeEnd`, which started colliding with real `TimeEnd` entries after the parsing fix.

- **`src/IcalService.ts`** — In `PreferDueDate` and `PreferStartDate`, check `TimeStart`+`TimeEnd` *before* the date-only branches, so `📅 2025-07-29 12:30-13:00` emits a timed event instead of an all-day one (the bug visible in #120's gist).

- **`src/Model/TaskSummary.ts`** — Strip the matched time range from the summary when a date is also present, so the time doesn't appear twice (once in DTSTART/DTEND, once as plain text in SUMMARY). Gated on date presence so dateless TODOs keep the time text in their summary.

- **`src/__tests__/InlineTimeRange.test.ts`** — End-to-end Jest tests covering the four issue reports plus regression checks for plain numbers, dates-as-times, and the dateless TODO case.

## Test plan

- [x] `bun run test` (Jest) — 126 passed
- [x] `bun test` (legacy iCal tests) — 102 passed
- [x] `bun build` — clean

Closes #144
Closes #120
Closes #109
Closes #89