### PR TITLE
Add CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,18 @@
+# Contributing
+
+Thanks for your interest in this plugin.
+
+This is a personal project that I maintain in my spare time, and I'm not currently looking for code contributions. To keep scope and review burden manageable, **pull requests are unlikely to be merged** unless they've been discussed and agreed in an issue first.
+
+## What's helpful
+
+- **Bug reports** — open an issue with steps to reproduce, your Obsidian version, and the plugin version.
+- **Feature ideas** — open an issue describing the use case. No guarantee it'll be built, but I read everything.
+- **Questions** — issues are fine for these too.
+
+## What's not helpful
+
+- Unsolicited pull requests, especially large refactors or stylistic changes.
+- AI-generated PRs without a prior issue.
+
+If you've found a security issue, please email me rather than opening a public issue.


### PR DESCRIPTION
Adds a bare-bones contributing guide to tick the hygiene box in Obsidian's plugin health checks. Politely makes clear that unsolicited PRs aren't welcome without prior issue discussion.