### PR TITLE
Add Done date event to CreateMultipleEvents

### DIFF
--- a/src/IcalService.ts
+++ b/src/IcalService.ts
@@ -92,6 +92,10 @@ export class IcalService {
             event += this.getEvent(task, task.getDate(TaskDateName.Due, 'YYYYMMDD'), '📅 ');
           }
 
+          if (task.hasA(TaskDateName.Done)) {
+            event += this.getEvent(task, task.getDate(TaskDateName.Done, 'YYYYMMDD'), '✅ ');
+          }
+
           if (event === '') {
             event += this.getEvent(task, task.getDate(null, 'YYYYMMDD'), '');
           }

--- a/src/__tests__/IcalService.test.ts
+++ b/src/__tests__/IcalService.test.ts
@@ -86,3 +86,43 @@ describe('IcalService location toggle', () => {
     expect(ical).not.toContain('LOCATION:');
   });
 });
+
+describe('IcalService CreateMultipleEvents — Done date', () => {
+  beforeEach(() => {
+    mockSettings.isIncludeLocation = true;
+    mockSettings.includeEventsOrTodos = 'EventsOnly';
+    mockSettings.howToProcessMultipleDates = 'CreateMultipleEvents';
+    mockSettings.isIncludeLinkInDescription = false;
+  });
+
+  it('emits an event on the done date', () => {
+    const dueDate = new Date(2026, 4, 15);
+    const doneDate = new Date(2026, 4, 18);
+    const task = new Task(
+      TaskStatus.Done,
+      [
+        { name: TaskDateName.Due, date: dueDate, isDateOnly: true } as any,
+        { name: TaskDateName.Done, date: doneDate, isDateOnly: true } as any,
+      ],
+      'Sample task',
+      'obsidian://open?vault=v&file=f',
+    );
+    const ical = new IcalService().getCalendar([task]);
+    expect(ical).toContain('DTSTART:20260515');
+    expect(ical).toContain('DTSTART:20260518');
+    expect(ical).toContain('SUMMARY:✅ ');
+  });
+
+  it('does not emit a done event when no done date is present', () => {
+    const dueDate = new Date(2026, 4, 15);
+    const task = new Task(
+      TaskStatus.ToDo,
+      [{ name: TaskDateName.Due, date: dueDate, isDateOnly: true } as any],
+      'Sample task',
+      'obsidian://open?vault=v&file=f',
+    );
+    const ical = new IcalService().getCalendar([task]);
+    expect(ical).toContain('DTSTART:20260515');
+    expect(ical).not.toContain('SUMMARY:✅ ');
+  });
+});


### PR DESCRIPTION
## Summary

When `howToProcessMultipleDates` is set to **Create multiple events**, also emit a VEVENT on the task's Done (✅) date if one is present.

## Why

The Done date often doesn't coincide with the Start/Scheduled/Due dates, and users want to see in their calendar when a task was actually completed. The Done date is already parsed (`TaskDateName.Done`, ✅ emoji in `src/Model/TaskDate.ts`); it was simply not emitted by the multi-event branch of `IcalService.getEvent`.

## Notes

- Completed tasks are filtered out earlier in `createTaskFromLine` when `ignoreCompletedTasks` is `true`, so no extra guard is needed in `IcalService`.
- Only affects the `CreateMultipleEvents` branch. PreferStart/PreferDue behaviour is unchanged.

## Test plan

- [x] Jest: new test asserts a task with both Due and Done dates emits two `DTSTART:` lines and a `SUMMARY:✅ …` event.
- [x] Jest: new test asserts a task without a Done date still emits only the Due event.
- [x] `bun run test` — 128 pass.
- [x] `bun run build` — clean (tsc + esbuild).

Closes #134