### PR TITLE
Fix typos in README Settings section

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ iCal has various settings which I will try to explain.
 
 ### Target directory
 
-This allows you to configure the plugin to scan for tasks in certain directories (or folders). For example, you might have a large vault with lots of information, but you only want to a calendar for tasks contains in your "Diary" directory. In this case, you would choose "/Diary".
+This allows you to configure the plugin to scan for tasks in certain directories (or folders). For example, you might have a large vault with lots of information, but you only want a calendar for tasks contained in your "Diary" directory. In this case, you would choose "/Diary".
 
 The default behaviour is to scan the entire vault for tasks, which is the "**/**" option.
 
@@ -76,7 +76,7 @@ This is to allow you to exclude completed tasks from being added to your calenda
 
 ### Add tasks as TODO items to your calendar
 
-By default the tasks discovered in your vault are treated as calendar events. This option allows you to also create calendar todo tasks. You have the option of choosing to just create calendar events, to just create TODO items, or to create both. Previously, there was an option to create just events or events and tasks. This has been expended to include just tasks as well. The default option is to create just calendar events.
+By default the tasks discovered in your vault are treated as calendar events. This option allows you to also create calendar todo tasks. You have the option of choosing to just create calendar events, to just create TODO items, or to create both. Previously, there was an option to create just events or events and tasks. This has been expanded to include just tasks as well. The default option is to create just calendar events.
 
 Some clients that support TODO items include Google Tasks, Microsoft Outlook, Microsoft To Do, Mozilla Thunderbird with Lightning Calendar, Android CalDAV-Sync, Calendars by Readdle, Todoist and OmniFocus.
 


### PR DESCRIPTION
## Summary
- Fix grammar in "Target directory" section ("want to a calendar for tasks contains" → "want a calendar for tasks contained")
- Fix typo in "Add tasks as TODO items" section ("expended" → "expanded")

## Test plan
- [x] Docs-only change, no code or behavior affected