### PR TITLE
Add status bar item showing scan progress and last sync time

### DIFF
--- a/src/Main.ts
+++ b/src/Main.ts
@@ -6,11 +6,13 @@ import { IcalService } from './IcalService';
 import { log } from './Logger';
 import { Task } from './Model/Task';
 import { settings } from './SettingsManager';
+import { StatusBar } from './StatusBar';
 import { TaskFinder } from './TaskFinder';
 import { Headings } from './Model/Headings';
 
 export class Main {
   app: App;
+  statusBar: StatusBar;
   iCalService: IcalService;
   githubClient: GithubClient;
   fileClient: FileClient;
@@ -18,8 +20,9 @@ export class Main {
   tasks: Task[];
   taskFinder: TaskFinder;
 
-  constructor(app: App) {
+  constructor(app: App, statusBar: StatusBar) {
     this.app = app;
+    this.statusBar = statusBar;
     this.iCalService = new IcalService();
     this.githubClient = new GithubClient();
     this.apiClient = new ApiClient(app.vault.getName(), settings.secretKey);
@@ -29,6 +32,16 @@ export class Main {
   }
 
   async start() {
+    try {
+      await this.scanAndSave();
+    } catch (error) {
+      log('Unexpected failure during scan/save', error);
+      this.statusBar.scanError(error);
+    }
+  }
+
+  private async scanAndSave() {
+    this.statusBar.scanning();
     let markdownFiles = this.app.vault.getMarkdownFiles();
 
     // Filter files based on the root path setting
@@ -84,37 +97,55 @@ export class Main {
     });
 
     log(`Found ${this.tasks.length} tasks`, this.tasks);
+    this.statusBar.building(this.tasks.length);
 
     // Build the calendar
     const calendar = this.iCalService.getCalendar(this.tasks);
     log('Calendar has been built', {calendar});
 
-    // Save to Gist
     if (settings.isSaveToGistEnabled) {
+      this.statusBar.saving('Gist');
       log('Saving calendar to Gist...');
-      await this.saveToGist(calendar);
-      log('Done');
+      try {
+        await this.saveToGist(calendar);
+        log('Done');
+      } catch (error) {
+        log('Failed to save calendar to Gist', error);
+        this.statusBar.saveError('Gist', error);
+      }
     } else {
       log('Skip saving calendar to Gist');
     }
 
-    // Save to file
     if (settings.isSaveToFileEnabled) {
+      this.statusBar.saving('File');
       log('Saving calendar to file...');
-      await this.saveToFile(calendar);
-      log('Done');
+      try {
+        await this.saveToFile(calendar);
+        log('Done');
+      } catch (error) {
+        log('Failed to save calendar to file', error);
+        this.statusBar.saveError('File', error);
+      }
     } else {
       log('Skip saving calendar to file');
     }
 
-    // Save to web
     if (settings.isSaveToWebEnabled) {
+      this.statusBar.saving('Web');
       log('Saving calendar to web...');
-      await this.saveToWeb(calendar);
-      log('Done');
+      try {
+        await this.saveToWeb(calendar);
+        log('Done');
+      } catch (error) {
+        log('Failed to save calendar to web', error);
+        this.statusBar.saveError('Web', error);
+      }
     } else {
       log('Skip saving calendar to web');
     }
+
+    this.statusBar.synced();
   }
 
   async saveToGist(calendar: string) {

--- a/src/ObsidianIcalPlugin.ts
+++ b/src/ObsidianIcalPlugin.ts
@@ -3,9 +3,11 @@ import { Main } from 'src/Main';
 import { log, logger } from './Logger';
 import { SettingTab } from './SettingTab';
 import { initSettingsManager, settings } from './SettingsManager';
+import { StatusBar } from './StatusBar';
 
 export default class ObsidianIcalPlugin extends Plugin {
   main: Main;
+  statusBar: StatusBar;
   periodicSaveInterval: number|null;
   validationRefreshInterval: number|null;
 
@@ -30,9 +32,8 @@ export default class ObsidianIcalPlugin extends Plugin {
     // // Perform additional things with the ribbon
     // ribbonIconEl.addClass("my-plugin-ribbon-class");
 
-    // // This adds a status bar item to the bottom of the app. Does not work on mobile apps.
-    // const statusBarItemEl = this.addStatusBarItem();
-    // statusBarItemEl.setText("Status Bar Text");
+    // Status bar item (no-op on mobile, where addStatusBarItem returns an element that doesn't render)
+    this.statusBar = new StatusBar(this.addStatusBarItem());
 
     // // This adds a simple command that can be triggered anywhere
     // this.addCommand({
@@ -90,7 +91,7 @@ export default class ObsidianIcalPlugin extends Plugin {
 
   // Once the Obsidian layout is ready, kick off a scan and configure periodic save
   async onLayoutReady(): Promise<void> {
-    this.main = new Main(this.app);
+    this.main = new Main(this.app, this.statusBar);
     await this.main.start();
 
     await this.configurePeriodicSave();

--- a/src/StatusBar.ts
+++ b/src/StatusBar.ts
@@ -1,0 +1,89 @@
+import { moment } from 'obsidian';
+
+type StageError = { stage: string; message: string };
+type State = 'idle' | 'scanning' | 'building' | 'saving' | 'synced' | 'error';
+
+export class StatusBar {
+  private el: HTMLElement | null;
+  private lastSyncAt: string | null = null;
+  private lastTaskCount: number | null = null;
+  private errors: StageError[] = [];
+
+  constructor(el: HTMLElement | null) {
+    this.el = el;
+    this.render('idle');
+  }
+
+  scanning(): void {
+    this.errors = [];
+    this.render('scanning');
+  }
+
+  building(taskCount: number): void {
+    this.lastTaskCount = taskCount;
+    this.render('building');
+  }
+
+  saving(destination: string): void {
+    this.render('saving', destination);
+  }
+
+  saveError(destination: string, error: unknown): void {
+    this.errors.push({ stage: destination, message: messageOf(error) });
+  }
+
+  synced(): void {
+    this.lastSyncAt = moment().format('HH:mm:ss');
+    this.render('synced');
+  }
+
+  scanError(error: unknown): void {
+    this.errors = [{ stage: 'Scan', message: messageOf(error) }];
+    this.render('error');
+  }
+
+  private render(state: State, destination?: string): void {
+    if (!this.el) return;
+
+    let text: string;
+    switch (state) {
+      case 'idle':
+        text = 'iCal: idle';
+        break;
+      case 'scanning':
+        text = 'iCal: scanning…';
+        break;
+      case 'building':
+        text = 'iCal: building calendar…';
+        break;
+      case 'saving':
+        text = `iCal: saving (${destination})…`;
+        break;
+      case 'synced':
+        text = this.errors.length
+          ? `iCal: synced ${this.lastSyncAt} (${this.errors.length} error${this.errors.length === 1 ? '' : 's'})`
+          : `iCal: synced ${this.lastSyncAt}`;
+        break;
+      case 'error':
+        text = 'iCal: sync failed';
+        break;
+    }
+    this.el.setText(text);
+
+    const tooltipParts: string[] = [];
+    if (this.lastSyncAt) tooltipParts.push(`Last sync: ${this.lastSyncAt}`);
+    if (this.lastTaskCount !== null) tooltipParts.push(`Tasks found: ${this.lastTaskCount}`);
+    for (const e of this.errors) tooltipParts.push(`Error (${e.stage}): ${e.message}`);
+    this.el.setAttr('aria-label', tooltipParts.join('\n') || 'Obsidian to iCal');
+  }
+}
+
+function messageOf(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === 'string') return error;
+  try {
+    return JSON.stringify(error);
+  } catch {
+    return String(error);
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a new `StatusBar` class that wraps Obsidian's status bar item and tracks state across the scan/save pipeline (scanning → building → saving per destination → synced / error).
- Status bar text is terse (`iCal: synced 14:23:07`); the tooltip carries detail (last sync time, task count, any per-destination errors).
- Each save destination (Gist / File / Web) is now wrapped in its own try/catch. A failure in one destination no longer prevents the others from running, and errors surface in the status bar tooltip instead of being silently logged.

Closes #10.

## Behaviour change worth flagging
Previously, an exception during a save bubbled up unhandled (visible only via the dev console / periodic-save logs). Now those errors are caught and surfaced via the status bar. Net positive, but technically observable: errors that used to be silent are now visible to the user.

## Test plan
- [x] `bun run build` passes (includes `tsc -noEmit` typecheck)
- [x] Manually verified in a test vault — status bar shows scanning, building, saving, and synced states
- [x] Verify error states render correctly (e.g. invalid GitHub PAT shows the Gist error in the tooltip)
- [x] Confirm behaviour on mobile is graceful (status bar element is created but doesn't render — no crashes expected)