### PR TITLE
Fix Gist saves missing auth token after settings change (#123)

### DIFF
--- a/src/GithubClient.ts
+++ b/src/GithubClient.ts
@@ -2,24 +2,17 @@ import { Octokit } from '@octokit/rest';
 import { settings } from './SettingsManager';
 
 export class GithubClient {
-  octokit: Octokit;
-
-  constructor() {
-    this.octokit = new Octokit({
+  async save(calendar: string) {
+    const octokit = new Octokit({
       auth: settings.githubPersonalAccessToken,
     });
-  }
-
-  async save(calendar: string) {
-    const f = settings.filename;
-    const options = {
+    await octokit.rest.gists.update({
       gist_id: settings.githubGistId,
       files: {
-        [f]: {
+        [settings.filename]: {
           content: calendar,
-        }
-      }
-    };
-    await this.octokit.rest.gists.update(options);
+        },
+      },
+    });
   }
 }


### PR DESCRIPTION
Fixes #123.

## Summary
- `GithubClient` constructed `Octokit` once in its constructor, capturing `settings.githubPersonalAccessToken` at plugin load.
- If the user pasted the token into settings after the plugin loaded (the natural first-install flow), the in-memory Octokit kept the empty default, so periodic saves sent unauthenticated `PATCH /gists/{id}` requests — which GitHub answers with `404 Not Found`.
- Moved Octokit construction into `save()` so each call reads the current token from `SettingsManager`. No Obsidian restart needed after token changes.

This also matches the unauthenticated-fetch symptom (no `Authorization` header) shown in the reporter's debug log, and the duplicate report quoted from #90.

## Test plan
- [x] Fresh install: enable plugin, paste a valid GitHub PAT + gist ID into settings, trigger a save → gist updates successfully without restarting Obsidian.
- [x] Change the PAT in settings to a new valid token, trigger a save → gist updates with the new token (not the previously cached one).
- [ ] Clear the PAT in settings, trigger a save → request fails (expected) rather than silently using a stale token.