### PR TITLE
Fix all-day event for CreateMultipleEvents + time range

### DIFF
--- a/src/IcalService.ts
+++ b/src/IcalService.ts
@@ -78,6 +78,15 @@ export class IcalService {
         // If there is a due date, then create an event for it
         // If there are no events, then take any old date that we can find
         case 'CreateMultipleEvents':
+          // An inline or Day Planner time range pins the task to a specific moment,
+          // so emit a single timed event instead of splitting into per-date all-day
+          // entries. Matches the short-circuit in PreferStartDate / PreferDueDate.
+          if (task.hasA(TaskDateName.TimeStart) && task.hasA(TaskDateName.TimeEnd)) {
+            event += 'DTSTART:' + task.getDate(TaskDateName.TimeStart, 'YYYYMMDD[T]HHmmss') + '\r\n';
+            event += 'DTEND:' + task.getDate(TaskDateName.TimeEnd, 'YYYYMMDD[T]HHmmss') + '\r\n';
+            break;
+          }
+
           event = '';
 
           if (task.hasA(TaskDateName.Start)) {

--- a/src/__tests__/CreateMultipleEventsWithTimeRange.test.ts
+++ b/src/__tests__/CreateMultipleEventsWithTimeRange.test.ts
@@ -1,0 +1,154 @@
+(global as any).window = {
+  crypto: {
+    randomUUID: () => '00000000-0000-0000-0000-000000000000',
+  },
+};
+
+jest.mock('obsidian', () => ({
+  moment: (input: Date | string) => {
+    const d = input instanceof Date ? input : new Date(input);
+    return {
+      format: (fmt: string) => {
+        const pad = (n: number, w = 2) => String(n).padStart(w, '0');
+        const yyyy = d.getFullYear();
+        const mm = pad(d.getMonth() + 1);
+        const dd = pad(d.getDate());
+        const hh = pad(d.getHours());
+        const mi = pad(d.getMinutes());
+        const ss = pad(d.getSeconds());
+        return fmt
+          .replace('YYYY', String(yyyy))
+          .replace('MM', mm)
+          .replace('DD', dd)
+          .replace('[T]', 'T')
+          .replace('HH', hh)
+          .replace('mm', mi)
+          .replace('ss', ss);
+      },
+    };
+  },
+  Plugin: class {},
+}));
+
+const mockSettings = {
+  includeEventsOrTodos: 'EventsOnly',
+  howToProcessMultipleDates: 'CreateMultipleEvents',
+  isIncludeLinkInDescription: false,
+  isIncludeLocation: false,
+  isOnlyTasksWithoutDatesAreTodos: true,
+  ignoreCompletedTasks: false,
+  ignoreOldTasks: false,
+  howToParseInternalLinks: 'DoNotModifyThem',
+};
+
+jest.mock('../SettingsManager', () => ({
+  settings: mockSettings,
+}));
+
+import { IcalService } from '../IcalService';
+import { createTaskFromLine } from '../Model/Task';
+
+function ical(line: string, dateOverride: Date | null = null): string {
+  const task = createTaskFromLine(line, 'obsidian://open?vault=v&file=f', dateOverride);
+  if (task === null) throw new Error('expected task, got null');
+  return new IcalService().getCalendar([task]);
+}
+
+// Asserts the event is properly time-bound: timed DTSTART, DTEND, no bare all-day DTSTART.
+function expectTimedEvent(out: string, startStamp: string, endStamp: string): void {
+  expect(out).toContain(`DTSTART:${startStamp}`);
+  expect(out).toContain(`DTEND:${endStamp}`);
+  // No bare all-day DTSTART line should appear
+  expect(out).not.toMatch(/DTSTART:\d{8}\r\n/);
+}
+
+describe('CreateMultipleEvents + time range (#164)', () => {
+  beforeEach(() => {
+    mockSettings.howToProcessMultipleDates = 'CreateMultipleEvents';
+    mockSettings.includeEventsOrTodos = 'EventsOnly';
+    mockSettings.isOnlyTasksWithoutDatesAreTodos = true;
+  });
+
+  describe('Day Planner override path (only TimeStart/TimeEnd produced)', () => {
+    it('emits a timed event for a task under a date heading', () => {
+      // Simulates a Kanban card under "## 2026-05-22": TaskFinder passes the heading's
+      // date as override; TaskDate then produces only TimeStart/TimeEnd, no Scheduled.
+      const out = ical('- [ ] 00:00 - 01:00 ⏳ 2026-05-22 TEST', new Date(2026, 4, 22));
+      expectTimedEvent(out, '20260522T000000', '20260522T010000');
+      expect(out).toContain('SUMMARY:🔲 TEST\r\n');
+    });
+
+    it('handles midnight start (00:00) without falling back to all-day', () => {
+      // Regression: a "00:00 - 01:00" range under a date heading previously dropped
+      // through to the all-day fallback because the CreateMultipleEvents branch
+      // didn't check TimeStart/TimeEnd at all.
+      const out = ical('- [ ] 00:00 - 01:00 TEST', new Date(2026, 4, 22));
+      expectTimedEvent(out, '20260522T000000', '20260522T010000');
+    });
+
+    it('handles a non-midnight time range under date heading', () => {
+      const out = ical('- [ ] 09:00 - 17:30 Work session', new Date(2026, 4, 22));
+      expectTimedEvent(out, '20260522T090000', '20260522T173000');
+    });
+
+    it('handles AM/PM time format under date heading', () => {
+      const out = ical('- [ ] 9am - 5pm Long day', new Date(2026, 4, 22));
+      expectTimedEvent(out, '20260522T090000', '20260522T170000');
+    });
+  });
+
+  describe('Inline time range path (Scheduled + TimeStart/TimeEnd produced)', () => {
+    it('emits a single timed event, not a date-only Scheduled event', () => {
+      // Inline format: no Day Planner override, the task line itself carries the
+      // emoji date AND a time range. Previously this still emitted DTSTART:20260522
+      // (date-only) because the Scheduled branch fired before checking TimeStart.
+      const out = ical('- [ ] foo 17:00-19:00 ⏳ 2026-05-22');
+      expectTimedEvent(out, '20260522T170000', '20260522T190000');
+      expect(out).toContain('SUMMARY:🔲 foo\r\n');
+    });
+
+    it('prefers the time range over a Start/Due date pair', () => {
+      // Even with multiple emoji dates, an inline time range should win — the
+      // user explicitly asked for a timed event.
+      const out = ical('- [ ] foo 09:00-10:00 🛫 2026-05-20 📅 2026-05-22');
+      expectTimedEvent(out, '20260520T090000', '20260520T100000');
+      expect(out).toContain('SUMMARY:🔲 foo\r\n');
+    });
+  });
+
+  describe('No time range — original CreateMultipleEvents behaviour preserved', () => {
+    it('still emits a Scheduled event for an emoji-only date task', () => {
+      const out = ical('- [ ] foo ⏳ 2026-05-22');
+      expect(out).toContain('DTSTART:20260522');
+      expect(out).toContain('SUMMARY:⏳ 🔲 foo');
+      expect(out).not.toMatch(/DTSTART:\d{8}T/); // no timed DTSTART
+    });
+
+    it('still emits separate Start and Due events when both are present', () => {
+      const out = ical('- [ ] foo 🛫 2026-05-20 📅 2026-05-22');
+      // Two VEVENT blocks, one per date
+      const eventCount = (out.match(/BEGIN:VEVENT/g) ?? []).length;
+      expect(eventCount).toBe(2);
+      expect(out).toContain('DTSTART:20260520');
+      expect(out).toContain('DTSTART:20260522');
+      expect(out).toContain('SUMMARY:🛫 🔲 foo');
+      expect(out).toContain('SUMMARY:📅 🔲 foo');
+    });
+  });
+
+  describe('DTSTAMP, UID, and structure', () => {
+    it('preserves DTSTAMP and UID lines when emitting the timed event', () => {
+      const out = ical('- [ ] 00:00 - 01:00 ⏳ 2026-05-22 TEST', new Date(2026, 4, 22));
+      expect(out).toMatch(/UID:[a-f0-9]+@obsidian-ical-plugin/);
+      expect(out).toContain('DTSTAMP:20260522T000000');
+    });
+
+    it('emits exactly one VEVENT for a time-ranged task', () => {
+      const out = ical('- [ ] 00:00 - 01:00 ⏳ 2026-05-22 TEST', new Date(2026, 4, 22));
+      const beginCount = (out.match(/BEGIN:VEVENT/g) ?? []).length;
+      const endCount = (out.match(/END:VEVENT/g) ?? []).length;
+      expect(beginCount).toBe(1);
+      expect(endCount).toBe(1);
+    });
+  });
+});


### PR DESCRIPTION
When howToProcessMultipleDates was 'CreateMultipleEvents' and a task carried a time range (either via Day Planner date-heading override or inline like '17:00-19:00 ⏳ 2026-05-22'), the resulting VEVENT had a date-only DTSTART and no DTEND. Google Calendar then rendered it as an all-day event.

The CreateMultipleEvents branch in IcalService only checked Start / Scheduled / Due / Done. Under Day Planner override, TaskDate produces only TimeStart and TimeEnd, so all four checks fell through to the 'no event matched' fallback which emits an all-day DTSTART.

- IcalService: short-circuit CreateMultipleEvents on TimeStart+TimeEnd to emit a single timed event, mirroring PreferStartDate and PreferDueDate.
- Tests: add CreateMultipleEventsWithTimeRange.test.ts covering the Day Planner override path, the inline emoji-date path, AM/PM and midnight ranges, and a regression check that emoji-only date tasks still produce the original per-date events.