### PR TITLE
Redact secretKey in debug log output

### DIFF
--- a/src/SettingsManager.ts
+++ b/src/SettingsManager.ts
@@ -44,6 +44,7 @@ class SettingsManager {
       githubPersonalAccessToken: '<redacted>',
       githubGistId: '<redacted>',
       githubUsername: '<redacted>',
+      secretKey: '<redacted>',
     });
   }
 


### PR DESCRIPTION
## Summary

- Adds `secretKey` to the redaction list in `SettingsManager.settingsWithoutSecrets()` so the obsidian-ical.com API bearer token doesn't leak to the console when debug mode is on.

Closes #165

## Test plan

- [x] `bun run build` passes (tsc + esbuild)
- [x] Toggle debug mode on, run a scan, confirm `secretKey` shows as `<redacted>` in the console alongside the other three secrets