### PR TITLE
Remove unused ical.js dependency

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -13,7 +13,6 @@
         "@typescript-eslint/eslint-plugin": "^8.34.1",
         "@typescript-eslint/parser": "^8.34.1",
         "esbuild": "^0.28.0",
-        "ical.js": "^2.1.0",
         "jest": "^30.2.0",
         "obsidian": "^1.8.7",
         "ts-jest": "^29.4.0",
@@ -626,8 +625,6 @@
     "http-errors": ["http-errors@2.0.0", "", { "dependencies": { "depd": "2.0.0", "inherits": "2.0.4", "setprototypeof": "1.2.0", "statuses": "2.0.1", "toidentifier": "1.0.1" } }, "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ=="],
 
     "human-signals": ["human-signals@2.1.0", "", {}, "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw=="],
-
-    "ical.js": ["ical.js@2.1.0", "", {}, "sha512-BOVfrH55xQ6kpS3muGvIXIg2l7p+eoe12/oS7R5yrO3TL/j/bLsR0PR+tYQESFbyTbvGgPHn9zQ6tI4FWyuSaQ=="],
 
     "iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "@typescript-eslint/eslint-plugin": "^8.34.1",
     "@typescript-eslint/parser": "^8.34.1",
     "esbuild": "^0.28.0",
-    "ical.js": "^2.1.0",
     "jest": "^30.2.0",
     "obsidian": "^1.8.7",
     "ts-jest": "^29.4.0",


### PR DESCRIPTION
## Summary
- Removes `ical.js` from `devDependencies` — it was never imported in `src/`
- Lockfile updated

## Test plan
- [x] `bun run test` — Jest: 148/148 pass
- [x] `bun test` — bun native: 102/102 pass
- [x] `bun run build` — clean
- [x] `grep -rn "ical\.js\|from 'ical'" src/` — no references

Fixes #168