### PR TITLE
Don't cache inactive-subscription validation responses

### DIFF
--- a/src/ApiClient.ts
+++ b/src/ApiClient.ts
@@ -44,8 +44,12 @@ export class ApiClient {
     })
       .then(response => {
         const validationResponse = ApiValidateResponse.fromResponse(response);
-        // Cache the successful response
-        this.validationCache.setCachedResponse(this.secretKey, validationResponse);
+        // Only cache active subscriptions. Caching an inactive response would
+        // make the user wait the full TTL (5 min) after fixing their billing
+        // before save() works again.
+        if (validationResponse.isSubscriptionActive()) {
+          this.validationCache.setCachedResponse(this.secretKey, validationResponse);
+        }
         return validationResponse;
       })
       .catch(error => {


### PR DESCRIPTION
## Summary
- `ApiClient.isActive()` now caches `/validate` responses only when `isSubscriptionActive()` is true
- Inactive responses fall through to a fresh request next call, so a user whose subscription was inactive can save immediately after fixing their billing instead of waiting up to 5 minutes for the cache TTL

## Test plan
- [x] `bun run test` — Jest: 148/148 pass
- [x] `bun test` — bun native: 102/102 pass
- [x] `bun run build` — clean
- [ ] Manual: deactivate subscription, observe failure → reactivate → confirm `save()` works on next invocation (no plugin reload)

Fixes #169