### PR TITLE
Replace ical.js with inline parser in legacy test

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -13,7 +13,6 @@
         "@typescript-eslint/eslint-plugin": "^8.34.1",
         "@typescript-eslint/parser": "^8.34.1",
         "esbuild": "^0.28.0",
-        "ical.js": "^2.1.0",
         "jest": "^30.2.0",
         "obsidian": "^1.8.7",
         "ts-jest": "^29.4.0",
@@ -626,8 +625,6 @@
     "http-errors": ["http-errors@2.0.0", "", { "dependencies": { "depd": "2.0.0", "inherits": "2.0.4", "setprototypeof": "1.2.0", "statuses": "2.0.1", "toidentifier": "1.0.1" } }, "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ=="],
 
     "human-signals": ["human-signals@2.1.0", "", {}, "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw=="],
-
-    "ical.js": ["ical.js@2.1.0", "", {}, "sha512-BOVfrH55xQ6kpS3muGvIXIg2l7p+eoe12/oS7R5yrO3TL/j/bLsR0PR+tYQESFbyTbvGgPHn9zQ6tI4FWyuSaQ=="],
 
     "iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "@typescript-eslint/eslint-plugin": "^8.34.1",
     "@typescript-eslint/parser": "^8.34.1",
     "esbuild": "^0.28.0",
-    "ical.js": "^2.1.0",
     "jest": "^30.2.0",
     "obsidian": "^1.8.7",
     "ts-jest": "^29.4.0",

--- a/test/test.test.js
+++ b/test/test.test.js
@@ -1,6 +1,72 @@
-const ICAL = require('ical.js');
 const fs = require('fs').promises;
 const path = require('path');
+
+// Minimal RFC 5545 parser producing the subset of jcal-shaped output that
+// these tests rely on: [componentName, [[propName, params, type, value], ...], [subcomponents]].
+// Type is always 'text' — the test only asserts on 'text' for the version row.
+function parseIcal(content) {
+  // Unfold continuation lines (RFC 5545 §3.1): lines beginning with WSP join
+  // the previous line, dropping the WSP.
+  const unfolded = content.replace(/\r?\n[ \t]/g, '');
+  const lines = unfolded.split(/\r?\n/).filter((l) => l.length > 0);
+
+  const cursor = { idx: 0 };
+  return parseComponent(lines, cursor);
+}
+
+function parseComponent(lines, cursor) {
+  const beginLine = lines[cursor.idx];
+  const beginMatch = beginLine && beginLine.match(/^BEGIN:(.+)$/i);
+  if (!beginMatch) {
+    throw new Error(`Expected BEGIN at line ${cursor.idx}: ${beginLine}`);
+  }
+  const name = beginMatch[1].trim().toLowerCase();
+  cursor.idx++;
+
+  const properties = [];
+  const subcomponents = [];
+  const endPattern = new RegExp(`^END:${name}$`, 'i');
+
+  while (cursor.idx < lines.length) {
+    const line = lines[cursor.idx];
+    if (endPattern.test(line.trim())) {
+      cursor.idx++;
+      return [name, properties, subcomponents];
+    }
+    if (/^BEGIN:/i.test(line)) {
+      subcomponents.push(parseComponent(lines, cursor));
+      continue;
+    }
+    const property = parseProperty(line);
+    if (property) properties.push(property);
+    cursor.idx++;
+  }
+  throw new Error(`Unclosed component ${name}`);
+}
+
+function parseProperty(line) {
+  const colonIdx = line.indexOf(':');
+  if (colonIdx === -1) return null;
+
+  const propPart = line.slice(0, colonIdx);
+  const rawValue = line.slice(colonIdx + 1);
+
+  const [propName, ...paramParts] = propPart.split(';');
+  const params = {};
+  paramParts.forEach((p) => {
+    const eq = p.indexOf('=');
+    if (eq > 0) {
+      params[p.slice(0, eq).toLowerCase()] = p.slice(eq + 1);
+    }
+  });
+
+  // Unescape RFC 5545 TEXT: \\, \;, \\ become literal; \n or \N become newline.
+  const value = rawValue.replace(/\\([,;\\])|\\([nN])/g, (_m, lit, nl) =>
+    lit !== undefined ? lit : '\n'
+  );
+
+  return [propName.toLowerCase(), params, 'text', value];
+}
 
 describe('Obsidian iCal Plugin - Legacy Integration Tests', () => {
   let jcalData;
@@ -10,7 +76,7 @@ describe('Obsidian iCal Plugin - Legacy Integration Tests', () => {
     try {
       const outputPath = path.join('test', 'obsidian-ical-plugin.ics');
       const icsContent = await fs.readFile(outputPath, 'utf-8');
-      jcalData = ICAL.parse(icsContent);
+      jcalData = parseIcal(icsContent);
 
       // Dynamically discover task IDs instead of hardcoding
       const allItems = jcalData[2] || [];


### PR DESCRIPTION
## Summary
- Replaces the single `ical.js` use site in `test/test.test.js` with a small inline RFC 5545 parser (~60 LOC)
- The parser produces the same jcal-shaped tuples (`[name, params, type, value]`) the existing assertions rely on, for the subset of properties they read (`prodid`, `version`, `summary`, `dtstart`, `dtend`)
- Handles line unfolding and TEXT-value unescaping defensively
- Removes `ical.js` from `devDependencies`

## Why
The previous PR (#171) tried to remove `ical.js` based on a `src/`-only grep. CI caught that the legacy test depended on it. This time the test is refactored first so the dependency can actually go away.

## Test plan
- [x] `bun test` — legacy: 102/102 pass
- [x] `bun run test` — Jest: 148/148 pass
- [x] `bun run build` — clean
- [x] `bun install` confirms `ical.js` removed from lockfile

Fixes #168