### PR TITLE
Add ignoreCancelledTasks setting (default true)

### DIFF
--- a/src/Model/Settings.ts
+++ b/src/Model/Settings.ts
@@ -32,6 +32,7 @@ export interface Settings {
   saveFileExtension: string;
   howToParseInternalLinks: string;
   ignoreCompletedTasks: boolean;
+  ignoreCancelledTasks: boolean;
   isDebug: boolean;
   includeEventsOrTodos: string;
   isOnlyTasksWithoutDatesAreTodos: boolean;
@@ -64,6 +65,7 @@ export const DEFAULT_SETTINGS: Settings = {
   saveFileExtension: '.ical',
   howToParseInternalLinks: 'DoNotModifyThem', // HOW_TO_PARSE_INTERNAL_LINKS.DoNotModifyThem,
   ignoreCompletedTasks: false,
+  ignoreCancelledTasks: true,
   isDebug: false,
   includeEventsOrTodos: 'EventsOnly', // INCLUDE_EVENTS_OR_TODOS.EventsOnly
   isOnlyTasksWithoutDatesAreTodos: true,

--- a/src/Model/Task.ts
+++ b/src/Model/Task.ts
@@ -124,6 +124,11 @@ export function createTaskFromLine(line: string, fileUri: string, dateOverride: 
     return null;
   }
 
+  // Task is cancelled and user wants to ignore cancelled tasks. Bail.
+  if (taskStatus === TaskStatus.Cancelled && settings.ignoreCancelledTasks === true) {
+    return null;
+  }
+
   const taskDates = getTaskDatesFromMarkdown(line, dateOverride);
 
   // Ignore old tasks is enabled, and all of the task's dates are after the retention period. Bail.

--- a/src/SettingTab.ts
+++ b/src/SettingTab.ts
@@ -325,6 +325,18 @@ export class SettingTab extends PluginSettingTab {
       );
 
     new Setting(containerEl)
+      .setName('Ignore cancelled tasks?')
+      .setDesc('Choose if you want your calendar to ignore tasks that have been cancelled (e.g. - [-] in Obsidian Tasks). Defaults to true since cancelled work is usually not something you want on your calendar.')
+      .addToggle((toggle: ToggleComponent) =>
+        toggle
+          .setValue(settings.ignoreCancelledTasks)
+          .onChange(async (value) => {
+            settings.ignoreCancelledTasks = value;
+            this.display();
+          })
+      );
+
+    new Setting(containerEl)
       .setName('Add tasks as TODO items to your calendar')
       .setDesc('Normally, we add your tasks as normal calendar events. You can choose to add your tasks as TODO items as well. Or you could add your tasks as calendar events as well as TODO items.')
       .addDropdown((dropdown: DropdownComponent) =>

--- a/src/SettingsManager.ts
+++ b/src/SettingsManager.ts
@@ -165,6 +165,15 @@ class SettingsManager {
     void this.saveSettings();
   }
 
+  public get ignoreCancelledTasks(): boolean {
+    return this.settings.ignoreCancelledTasks;
+  }
+
+  public set ignoreCancelledTasks(ignoreCancelledTasks: boolean) {
+    this.settings.ignoreCancelledTasks = ignoreCancelledTasks;
+    void this.saveSettings();
+  }
+
   public get isDebug(): boolean {
     return this.settings.isDebug;
   }

--- a/src/__tests__/Settings.test.ts
+++ b/src/__tests__/Settings.test.ts
@@ -23,6 +23,7 @@ describe('Settings', () => {
       expect(DEFAULT_SETTINGS).toHaveProperty('saveFileExtension');
       expect(DEFAULT_SETTINGS).toHaveProperty('howToParseInternalLinks');
       expect(DEFAULT_SETTINGS).toHaveProperty('ignoreCompletedTasks');
+      expect(DEFAULT_SETTINGS).toHaveProperty('ignoreCancelledTasks');
       expect(DEFAULT_SETTINGS).toHaveProperty('isDebug');
       expect(DEFAULT_SETTINGS).toHaveProperty('includeEventsOrTodos');
       expect(DEFAULT_SETTINGS).toHaveProperty('isOnlyTasksWithoutDatesAreTodos');
@@ -49,6 +50,7 @@ describe('Settings', () => {
       expect(DEFAULT_SETTINGS.isSaveToWebEnabled).toBe(false);
       expect(DEFAULT_SETTINGS.saveFileExtension).toBe('.ical');
       expect(DEFAULT_SETTINGS.ignoreCompletedTasks).toBe(false);
+      expect(DEFAULT_SETTINGS.ignoreCancelledTasks).toBe(true);
       expect(DEFAULT_SETTINGS.isDebug).toBe(false);
       expect(DEFAULT_SETTINGS.includeEventsOrTodos).toBe('EventsOnly');
       expect(DEFAULT_SETTINGS.isOnlyTasksWithoutDatesAreTodos).toBe(true);

--- a/src/__tests__/Task.test.ts
+++ b/src/__tests__/Task.test.ts
@@ -3,6 +3,19 @@ jest.mock('obsidian', () => ({
   Plugin: class {},
 }));
 
+const mockSettings = {
+  includeEventsOrTodos: 'EventsAndTodos',
+  ignoreCompletedTasks: false,
+  ignoreCancelledTasks: true,
+  ignoreOldTasks: false,
+  oldTaskInDays: 365,
+  howToParseInternalLinks: 'DoNotModifyThem',
+};
+
+jest.mock('../SettingsManager', () => ({
+  settings: mockSettings,
+}));
+
 import { Task, createTaskFromLine } from '../Model/Task';
 import { TaskStatus } from '../Model/TaskStatus';
 
@@ -17,6 +30,55 @@ describe('createTaskFromLine', () => {
 
   it('returns null when line is an empty string', () => {
     expect(createTaskFromLine('', 'obsidian://open?vault=v&file=f', null)).toBeNull();
+  });
+});
+
+describe('createTaskFromLine: cancelled task filter', () => {
+  beforeEach(() => {
+    mockSettings.ignoreCancelledTasks = true;
+    mockSettings.ignoreCompletedTasks = false;
+    mockSettings.includeEventsOrTodos = 'EventsAndTodos';
+    mockSettings.ignoreOldTasks = false;
+    mockSettings.howToParseInternalLinks = 'DoNotModifyThem';
+  });
+
+  it('drops a cancelled task with a date when ignoreCancelledTasks is true', () => {
+    const line = '- [-] Cancelled meeting 📅 2026-04-20';
+    expect(createTaskFromLine(line, 'obsidian://open?vault=v&file=f', null)).toBeNull();
+  });
+
+  it('drops a cancelled task without a date when ignoreCancelledTasks is true and TODOs are enabled', () => {
+    const line = '- [-] Cancelled chore';
+    expect(createTaskFromLine(line, 'obsidian://open?vault=v&file=f', null)).toBeNull();
+  });
+
+  it('keeps a cancelled task with a date when ignoreCancelledTasks is false', () => {
+    mockSettings.ignoreCancelledTasks = false;
+    const line = '- [-] Cancelled meeting 📅 2026-04-20';
+    const task = createTaskFromLine(line, 'obsidian://open?vault=v&file=f', null);
+    expect(task).not.toBeNull();
+    expect(task?.status).toBe(TaskStatus.Cancelled);
+  });
+
+  it('does not affect non-cancelled tasks (Done, ToDo, InProgress)', () => {
+    mockSettings.ignoreCancelledTasks = true;
+    const todoTask = createTaskFromLine('- [ ] Todo task 📅 2026-04-20', 'obsidian://open?vault=v&file=f', null);
+    const doneTask = createTaskFromLine('- [x] Done task 📅 2026-04-20', 'obsidian://open?vault=v&file=f', null);
+    const inProgressTask = createTaskFromLine('- [/] In progress task 📅 2026-04-20', 'obsidian://open?vault=v&file=f', null);
+
+    expect(todoTask?.status).toBe(TaskStatus.ToDo);
+    expect(doneTask?.status).toBe(TaskStatus.Done);
+    expect(inProgressTask?.status).toBe(TaskStatus.InProgress);
+  });
+
+  it('honours ignoreCompletedTasks independently of ignoreCancelledTasks', () => {
+    mockSettings.ignoreCancelledTasks = true;
+    mockSettings.ignoreCompletedTasks = true;
+    const doneTask = createTaskFromLine('- [x] Done task 📅 2026-04-20', 'obsidian://open?vault=v&file=f', null);
+    const cancelledTask = createTaskFromLine('- [-] Cancelled task 📅 2026-04-20', 'obsidian://open?vault=v&file=f', null);
+
+    expect(doneTask).toBeNull();
+    expect(cancelledTask).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary
- Adds `ignoreCancelledTasks: boolean` setting, defaulting to `true`
- Filters `TaskStatus.Cancelled` tasks in `createTaskFromLine` when the setting is on (mirrors the existing `ignoreCompletedTasks` pattern)
- Adds a UI toggle in the "Task Processing" section
- 5 new unit tests covering: default-on filtering, off-state passthrough, no-impact on other statuses, interaction with `ignoreCompletedTasks`, and behaviour without a date

## Why default `true`?
Cancelled work usually shouldn't appear on a calendar — that's the product question this PR resolves. Users who want the old behaviour can flip the toggle off; existing on-disk settings without the field merge through `DEFAULT_SETTINGS` and get `true`.

## Test plan
- [x] `bun run test` — Jest: 153/153 pass (5 new tests)
- [x] `bun test` — bun native: 102/102 pass
- [x] `bun run build` — clean

Fixes #174