### PR TITLE
Preserve unknown subscription statuses instead of coercing to CANCELED

### DIFF
--- a/src/Model/Api/ValidateResponse.ts
+++ b/src/Model/Api/ValidateResponse.ts
@@ -11,6 +11,11 @@ export enum SubscriptionStatus {
   PAUSED = 'paused',
   TRIALING = 'trialing',
   UNPAID = 'unpaid',
+  // Returned when the API status string is empty or doesn't match any of the
+  // known Stripe statuses above. Preserves the original string in rawStatus
+  // so it's still diagnosable from the UI / debug log without misreporting
+  // the user as CANCELED.
+  UNKNOWN = 'unknown',
 }
 
 export interface ApiErrorResponseData {
@@ -44,28 +49,31 @@ export interface ApiValidateResponseData {
 
 export class ApiValidateResponse {
   status: SubscriptionStatus;
+  rawStatus: string;
   expiresAt: Date | null;
   message: string;
 
   constructor(data: ApiValidateResponseData) {
     log('ApiValidateResponseData:', data);
-    // Convert string status to enum and validate
-    this.status = this.parseStatus(data.data.subscription.status);
+    this.rawStatus = data.data.subscription.status ?? '';
+    this.status = this.parseStatus(this.rawStatus);
     this.expiresAt = data.data.subscription.expiresAt ? new Date(data.data.subscription.expiresAt) : null;
     this.message = data.message;
   }
 
   private parseStatus(status: string): SubscriptionStatus {
-    const normalizedStatus = status.toLowerCase();
+    const normalizedStatus = (status ?? '').toLowerCase();
 
-    // Check if it's a valid status
-    if (Object.values(SubscriptionStatus).includes(normalizedStatus as SubscriptionStatus)) {
+    // Match against a known status. Stripe may introduce new statuses, and the
+    // API may return values from a non-Stripe billing source — those land in
+    // UNKNOWN rather than getting silently coerced to CANCELED.
+    if (Object.values(SubscriptionStatus).includes(normalizedStatus as SubscriptionStatus)
+      && normalizedStatus !== SubscriptionStatus.UNKNOWN) {
       return normalizedStatus as SubscriptionStatus;
     }
 
-    // Default to CANCELED if not recognized
     log(`Unrecognized subscription status:`, status);
-    return SubscriptionStatus.CANCELED;
+    return SubscriptionStatus.UNKNOWN;
   }
 
   isSubscriptionActive(): boolean {

--- a/src/SettingTab.ts
+++ b/src/SettingTab.ts
@@ -58,7 +58,9 @@ export class SettingTab extends PluginSettingTab {
 
     if (cachedValidation) {
       this.isSecretKeyValid = cachedValidation.isSubscriptionActive();
-      this.subscriptionStatus = cachedValidation.status;
+      // Use the raw API status string so genuinely unknown statuses are still
+      // shown verbatim instead of as the literal 'unknown' enum value.
+      this.subscriptionStatus = cachedValidation.rawStatus || cachedValidation.status;
       this.subscriptionExpiresAt = cachedValidation.expiresAt?.toISOString() || null;
 
       // Get calendar info

--- a/src/__tests__/ValidateResponse.test.ts
+++ b/src/__tests__/ValidateResponse.test.ts
@@ -1,0 +1,93 @@
+jest.mock('obsidian', () => ({
+  Plugin: class {},
+}));
+
+import { ApiValidateResponse, SubscriptionStatus } from '../Model/Api/ValidateResponse';
+
+function build(status: string, expiresAt: string | null = '2030-01-01T00:00:00Z'): ApiValidateResponse {
+  return new ApiValidateResponse({
+    data: {
+      subscription: {
+        status,
+        expiresAt: expiresAt as unknown as string,
+      },
+    },
+    message: 'ok',
+  });
+}
+
+describe('ApiValidateResponse.parseStatus', () => {
+  it.each([
+    ['active', SubscriptionStatus.ACTIVE],
+    ['canceled', SubscriptionStatus.CANCELED],
+    ['incomplete', SubscriptionStatus.INCOMPLETE],
+    ['incomplete_expired', SubscriptionStatus.INCOMPLETE_EXPIRED],
+    ['past_due', SubscriptionStatus.PAST_DUE],
+    ['paused', SubscriptionStatus.PAUSED],
+    ['trialing', SubscriptionStatus.TRIALING],
+    ['unpaid', SubscriptionStatus.UNPAID],
+  ])('recognises known Stripe status %s', (raw, expected) => {
+    const r = build(raw);
+    expect(r.status).toBe(expected);
+    expect(r.rawStatus).toBe(raw);
+  });
+
+  it('normalises mixed-case input to the matching enum value', () => {
+    const r = build('Active');
+    expect(r.status).toBe(SubscriptionStatus.ACTIVE);
+    expect(r.rawStatus).toBe('Active');
+  });
+
+  it('returns UNKNOWN for an unrecognised status and preserves rawStatus', () => {
+    const r = build('something_new');
+    expect(r.status).toBe(SubscriptionStatus.UNKNOWN);
+    expect(r.rawStatus).toBe('something_new');
+  });
+
+  it('returns UNKNOWN for an empty string', () => {
+    const r = build('');
+    expect(r.status).toBe(SubscriptionStatus.UNKNOWN);
+    expect(r.rawStatus).toBe('');
+  });
+
+  it('returns UNKNOWN when the input is the literal "unknown" string', () => {
+    // Defensive: the API shouldn't return this, but if it does we don't want
+    // an UNKNOWN sentinel to be silently treated as a "real" recognised status.
+    const r = build('unknown');
+    expect(r.status).toBe(SubscriptionStatus.UNKNOWN);
+    expect(r.rawStatus).toBe('unknown');
+  });
+});
+
+describe('ApiValidateResponse.isSubscriptionActive', () => {
+  it('returns true only for ACTIVE', () => {
+    expect(build('active').isSubscriptionActive()).toBe(true);
+  });
+
+  it.each([
+    'canceled',
+    'past_due',
+    'paused',
+    'trialing', // trial is not the same as active per current logic
+    'unpaid',
+    'incomplete',
+    'incomplete_expired',
+    'gibberish',
+    '',
+  ])('returns false for %s', (status) => {
+    expect(build(status).isSubscriptionActive()).toBe(false);
+  });
+});
+
+describe('ApiValidateResponse.expiresAt', () => {
+  it('parses an ISO date when present', () => {
+    const r = build('active', '2030-06-15T12:00:00Z');
+    expect(r.expiresAt).toBeInstanceOf(Date);
+    expect(r.expiresAt?.toISOString()).toBe('2030-06-15T12:00:00.000Z');
+  });
+
+  it('is null when expiresAt is empty', () => {
+    const r = build('active', '');
+    expect(r.expiresAt).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `SubscriptionStatus.UNKNOWN`
- Adds `rawStatus: string` field on `ApiValidateResponse` to preserve the original API string for diagnostics
- `parseStatus` returns `UNKNOWN` (not `CANCELED`) when the API returns something unrecognised
- `SettingTab` displays the raw status string so the user sees `⚠️ foo` when the API actually returned `foo`, rather than the literal `unknown`
- 24 new unit tests in `src/__tests__/ValidateResponse.test.ts`

## Why
The previous behaviour misreported users as cancelled if Stripe added a new status the plugin didn't know about (or if the backend used a non-Stripe billing source). Now unknown statuses are clearly flagged and not confused with a real cancellation.

## Test plan
- [x] `bun run test` — Jest: 177/177 pass (24 new tests)
- [x] `bun test` — bun native: 102/102 pass
- [x] `bun run build` — clean

Fixes #176