### PR TITLE
Stop firing getCalendar() on every SettingTab re-render

### DIFF
--- a/src/CalendarInfoFetcher.ts
+++ b/src/CalendarInfoFetcher.ts
@@ -1,0 +1,65 @@
+import { ApiClient } from './ApiClient';
+
+export interface CalendarInfo {
+  url: string;
+  updatedAt: string;
+}
+
+// Gate around ApiClient.getCalendar() so the Settings tab only hits the
+// network once per validation cycle. Previously getCalendar() fired on every
+// SettingTab.display() re-render — which happens for every toggle click —
+// generating a flood of HTTP requests. Reset on key change to allow a fresh
+// fetch for the new key.
+export class CalendarInfoFetcher {
+  private hasAttemptedFetch: boolean = false;
+  private isFetching: boolean = false;
+  private cached: CalendarInfo | null = null;
+
+  reset(): void {
+    this.hasAttemptedFetch = false;
+    this.cached = null;
+  }
+
+  get info(): CalendarInfo | null {
+    return this.cached;
+  }
+
+  get hasAttempted(): boolean {
+    return this.hasAttemptedFetch;
+  }
+
+  async fetchOnce(client: ApiClient): Promise<CalendarInfo | null> {
+    if (this.hasAttemptedFetch || this.isFetching) {
+      return this.cached;
+    }
+    return this.runFetch(client);
+  }
+
+  async forceRefetch(client: ApiClient): Promise<CalendarInfo | null> {
+    if (this.isFetching) {
+      return this.cached;
+    }
+    this.reset();
+    return this.runFetch(client);
+  }
+
+  private async runFetch(client: ApiClient): Promise<CalendarInfo | null> {
+    this.isFetching = true;
+    try {
+      const response = await client.getCalendar();
+      if (response.found && response.url && response.updatedAt) {
+        this.cached = { url: response.url, updatedAt: response.updatedAt };
+      } else {
+        this.cached = null;
+      }
+    } catch {
+      // Swallow — calendar URL just won't appear. The validation status is
+      // owned by the separate ApiClient.isActive cache.
+      this.cached = null;
+    } finally {
+      this.isFetching = false;
+      this.hasAttemptedFetch = true;
+    }
+    return this.cached;
+  }
+}

--- a/src/SettingTab.ts
+++ b/src/SettingTab.ts
@@ -14,6 +14,7 @@ import { log } from './Logger';
 import ObsidianIcalPlugin from './ObsidianIcalPlugin';
 import { settings } from './SettingsManager';
 import {apiClient} from "./ApiClient";
+import { CalendarInfoFetcher } from './CalendarInfoFetcher';
 
 export class SettingTab extends PluginSettingTab {
   plugin: ObsidianIcalPlugin;
@@ -22,6 +23,7 @@ export class SettingTab extends PluginSettingTab {
   subscriptionStatus: string | null = null;
   subscriptionExpiresAt: string | null = null;
   calendarUpdatedAt: string | null = null;
+  private calendarFetcher: CalendarInfoFetcher = new CalendarInfoFetcher();
 
   constructor(app: App, plugin: ObsidianIcalPlugin) {
     super(app, plugin);
@@ -45,6 +47,9 @@ export class SettingTab extends PluginSettingTab {
     this.subscriptionExpiresAt = null;
     this.calendarUrl = null;
     this.calendarUpdatedAt = null;
+    // Reset the fetch gate so a new (or re-validated) key fetches fresh
+    // calendar info next time display() runs.
+    this.calendarFetcher.reset();
   }
 
   private updateMemberStatusFromCache(): void {
@@ -63,15 +68,24 @@ export class SettingTab extends PluginSettingTab {
       this.subscriptionStatus = cachedValidation.rawStatus || cachedValidation.status;
       this.subscriptionExpiresAt = cachedValidation.expiresAt?.toISOString() || null;
 
-      // Get calendar info
-      client.getCalendar().then(calendarResponse => {
-        if (calendarResponse.found) {
-          this.calendarUrl = calendarResponse.url;
-          this.calendarUpdatedAt = calendarResponse.updatedAt;
-        }
-      }).catch(() => {
-        // Ignore calendar fetch errors
-      });
+      // Populate the calendar URL from the fetch cache if we've already
+      // fetched once. Settings re-renders (every toggle, every onChange)
+      // must not re-fire getCalendar() — that's why we gate on hasAttempted.
+      const cachedInfo = this.calendarFetcher.info;
+      if (cachedInfo) {
+        this.calendarUrl = cachedInfo.url;
+        this.calendarUpdatedAt = cachedInfo.updatedAt;
+      }
+
+      if (this.isSecretKeyValid && !this.calendarFetcher.hasAttempted) {
+        void this.calendarFetcher.fetchOnce(client).then((info) => {
+          if (info) {
+            this.calendarUrl = info.url;
+            this.calendarUpdatedAt = info.updatedAt;
+            this.display();
+          }
+        });
+      }
     } else {
       // No cache yet - trigger background validation for valid-looking secret key
       void this.validateSecretKeyInBackground(settings.secretKey);
@@ -287,6 +301,22 @@ export class SettingTab extends PluginSettingTab {
                 window.setTimeout(() => {
                   button.setButtonText('📋 Copy to clipboard');
                 }, 500);
+              });
+          })
+          .addButton((button: ButtonComponent) => {
+            button
+              .setButtonText('🔄 Refresh')
+              .setTooltip('Re-fetch calendar info from the server')
+              .onClick(async () => {
+                if (!settings.secretKey || settings.secretKey.length !== 32) return;
+                const client = apiClient(this.app.vault.getName(), settings.secretKey);
+                button.setButtonText('⏳ Refreshing…');
+                const info = await this.calendarFetcher.forceRefetch(client);
+                if (info) {
+                  this.calendarUrl = info.url;
+                  this.calendarUpdatedAt = info.updatedAt;
+                }
+                this.display();
               });
           });
       } else {

--- a/src/__tests__/CalendarInfoFetcher.test.ts
+++ b/src/__tests__/CalendarInfoFetcher.test.ts
@@ -1,0 +1,137 @@
+jest.mock('obsidian', () => ({
+  Plugin: class {},
+}));
+
+import { CalendarInfoFetcher } from '../CalendarInfoFetcher';
+import { ApiClient } from '../ApiClient';
+
+type FoundCalendar = { found: true; url: string; updatedAt: string };
+type NotFoundCalendar = { found: false; url: null; updatedAt: null };
+
+function makeClient(responses: Array<FoundCalendar | NotFoundCalendar | Error>): {
+  client: ApiClient;
+  getCalendar: jest.Mock;
+} {
+  const queue = [...responses];
+  const getCalendar = jest.fn().mockImplementation(() => {
+    const next = queue.shift();
+    if (next instanceof Error) return Promise.reject(next);
+    return Promise.resolve(next);
+  });
+  return { client: { getCalendar } as unknown as ApiClient, getCalendar };
+}
+
+describe('CalendarInfoFetcher', () => {
+  it('starts with no cached info and hasAttempted false', () => {
+    const fetcher = new CalendarInfoFetcher();
+    expect(fetcher.info).toBeNull();
+    expect(fetcher.hasAttempted).toBe(false);
+  });
+
+  it('fetches once and caches the result', async () => {
+    const { client, getCalendar } = makeClient([
+      { found: true, url: 'https://x.com/cal', updatedAt: '2026-05-27T10:00:00Z' },
+    ]);
+    const fetcher = new CalendarInfoFetcher();
+
+    const info = await fetcher.fetchOnce(client);
+    expect(info).toEqual({ url: 'https://x.com/cal', updatedAt: '2026-05-27T10:00:00Z' });
+    expect(fetcher.info).toEqual(info);
+    expect(fetcher.hasAttempted).toBe(true);
+    expect(getCalendar).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not refetch on subsequent fetchOnce calls', async () => {
+    const { client, getCalendar } = makeClient([
+      { found: true, url: 'https://x.com/cal', updatedAt: '2026-05-27T10:00:00Z' },
+    ]);
+    const fetcher = new CalendarInfoFetcher();
+
+    await fetcher.fetchOnce(client);
+    await fetcher.fetchOnce(client);
+    await fetcher.fetchOnce(client);
+
+    expect(getCalendar).toHaveBeenCalledTimes(1);
+  });
+
+  it('dedupes concurrent fetchOnce calls', async () => {
+    let resolve!: (v: FoundCalendar) => void;
+    const pending = new Promise<FoundCalendar>((res) => {
+      resolve = res;
+    });
+    const getCalendar = jest.fn().mockReturnValue(pending);
+    const client = { getCalendar } as unknown as ApiClient;
+    const fetcher = new CalendarInfoFetcher();
+
+    const p1 = fetcher.fetchOnce(client);
+    const p2 = fetcher.fetchOnce(client);
+    resolve({ found: true, url: 'https://x.com/cal', updatedAt: '2026-05-27T10:00:00Z' });
+    const [r1, r2] = await Promise.all([p1, p2]);
+
+    expect(getCalendar).toHaveBeenCalledTimes(1);
+    expect(r1).toEqual({ url: 'https://x.com/cal', updatedAt: '2026-05-27T10:00:00Z' });
+    expect(r2).toBeNull();
+  });
+
+  it('records hasAttempted even when the calendar is not found', async () => {
+    const { client, getCalendar } = makeClient([
+      { found: false, url: null, updatedAt: null },
+    ]);
+    const fetcher = new CalendarInfoFetcher();
+
+    const info = await fetcher.fetchOnce(client);
+    expect(info).toBeNull();
+    expect(fetcher.hasAttempted).toBe(true);
+    expect(getCalendar).toHaveBeenCalledTimes(1);
+
+    await fetcher.fetchOnce(client);
+    expect(getCalendar).toHaveBeenCalledTimes(1);
+  });
+
+  it('records hasAttempted even when getCalendar throws', async () => {
+    const { client, getCalendar } = makeClient([new Error('network down')]);
+    const fetcher = new CalendarInfoFetcher();
+
+    const info = await fetcher.fetchOnce(client);
+    expect(info).toBeNull();
+    expect(fetcher.hasAttempted).toBe(true);
+    expect(getCalendar).toHaveBeenCalledTimes(1);
+
+    await fetcher.fetchOnce(client);
+    expect(getCalendar).toHaveBeenCalledTimes(1);
+  });
+
+  it('reset() clears cache and hasAttempted so the next fetch hits the network', async () => {
+    const { client, getCalendar } = makeClient([
+      { found: true, url: 'https://x.com/cal-1', updatedAt: '2026-05-27T10:00:00Z' },
+      { found: true, url: 'https://x.com/cal-2', updatedAt: '2026-05-27T11:00:00Z' },
+    ]);
+    const fetcher = new CalendarInfoFetcher();
+
+    await fetcher.fetchOnce(client);
+    expect(fetcher.info?.url).toBe('https://x.com/cal-1');
+
+    fetcher.reset();
+    expect(fetcher.hasAttempted).toBe(false);
+    expect(fetcher.info).toBeNull();
+
+    await fetcher.fetchOnce(client);
+    expect(fetcher.info?.url).toBe('https://x.com/cal-2');
+    expect(getCalendar).toHaveBeenCalledTimes(2);
+  });
+
+  it('forceRefetch() bypasses the once-gate and replaces the cache', async () => {
+    const { client, getCalendar } = makeClient([
+      { found: true, url: 'https://x.com/cal-1', updatedAt: '2026-05-27T10:00:00Z' },
+      { found: true, url: 'https://x.com/cal-2', updatedAt: '2026-05-27T11:00:00Z' },
+    ]);
+    const fetcher = new CalendarInfoFetcher();
+
+    await fetcher.fetchOnce(client);
+    expect(fetcher.info?.url).toBe('https://x.com/cal-1');
+
+    const refreshed = await fetcher.forceRefetch(client);
+    expect(refreshed?.url).toBe('https://x.com/cal-2');
+    expect(getCalendar).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary
- Every Settings-panel toggle re-rendered `display()` → `updateMemberStatusFromCache()` → unconditionally fired `client.getCalendar()`. One user toggle = one HTTP request. Plus the recursive `this.display()` from background validation multiplied the effect.
- New `CalendarInfoFetcher` gate fetches at most once per validation cycle and dedupes concurrent calls
- `SettingTab.updateMemberStatusFromCache` now uses `fetchOnce`; subsequent renders read cached info without network
- `clearMemberStatus` resets the gate so changing the secret key forces a fresh fetch
- New 🔄 Refresh button on the Calendar URL row for explicit user-triggered refetches via `forceRefetch()`

## Testing
- 8 new unit tests in `src/__tests__/CalendarInfoFetcher.test.ts` covering:
  - First fetch caches; subsequent calls don't hit the network
  - Concurrent `fetchOnce` calls dedupe to a single network call
  - "Not found" responses still record `hasAttempted` so we don't retry forever
  - Errors don't unjam the gate (no retry storm)
  - `reset()` clears state for a fresh fetch
  - `forceRefetch()` bypasses the gate
- All existing 177 jest tests + 102 bun-native tests still pass

The SettingTab integration itself isn't unit-tested (no test harness for `PluginSettingTab`), but the high-risk behavior — "is the network called more than once per session" — is fully covered at the fetcher layer, and the SettingTab change is a thin adapter on top of it.

## Test plan
- [x] `bun run test` — Jest: 185/185 pass (8 new tests)
- [x] `bun test` — bun native: 102/102 pass
- [x] `bun run build` — clean
- [ ] Manual: open Settings with a valid member key → toggle "Save to disk" several times → confirm only one network request to `/api/calendar/<vault>` in DevTools Network tab
- [ ] Manual: click the new 🔄 Refresh button → confirm one fresh network request

Fixes #175