### PR TITLE
Enable TypeScript strict mode

### DIFF
--- a/src/ObsidianIcalPlugin.ts
+++ b/src/ObsidianIcalPlugin.ts
@@ -6,10 +6,10 @@ import { initSettingsManager, settings } from './SettingsManager';
 import { StatusBar } from './StatusBar';
 
 export default class ObsidianIcalPlugin extends Plugin {
-  main: Main;
-  statusBar: StatusBar;
-  periodicSaveInterval: number|null;
-  validationRefreshInterval: number|null;
+  main!: Main;
+  statusBar!: StatusBar;
+  periodicSaveInterval: number | null = null;
+  validationRefreshInterval: number | null = null;
 
   async onload() {
     // Initialise SettingsManager

--- a/src/SettingTab.ts
+++ b/src/SettingTab.ts
@@ -597,7 +597,8 @@ export class SettingTab extends PluginSettingTab {
                 settings.githubPersonalAccessToken = value;
               } catch(error) {
                 log('Error!', error);
-                githubPersonalAccessTokenErrorElement.innerText = `${error.message ?? 'Unknown error'}`;
+                const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+                githubPersonalAccessTokenErrorElement.innerText = errorMessage;
               }
             })
         );

--- a/src/SettingsManager.ts
+++ b/src/SettingsManager.ts
@@ -5,13 +5,13 @@ import { DEFAULT_SETTINGS, Settings } from './Model/Settings';
 // Settings class in instantiated using a singleton pattern
 class SettingsManager {
   private static instance: SettingsManager;
-  private settings: Settings;
+  // Populated by loadSettings() which is awaited from createInstance() before
+  // anyone can read settings — strict-mode definite-assignment is safe here.
+  private settings!: Settings;
   private plugin: Plugin;
 
-  private constructor(plugin?: Plugin) {
-    if (plugin instanceof Plugin) {
-      this.plugin = plugin;
-    }
+  private constructor(plugin: Plugin) {
+    this.plugin = plugin;
   }
 
   public static async createInstance(plugin: Plugin): Promise<SettingsManager> {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,11 +6,10 @@
     "module": "ESNext",
     "target": "ES2018",
     "allowJs": true,
-    "noImplicitAny": true,
+    "strict": true,
     "moduleResolution": "node",
     "importHelpers": true,
     "isolatedModules": true,
-	  "strictNullChecks": true,
     "lib": [
       "DOM",
       "ES5",


### PR DESCRIPTION
## Summary
- `tsconfig.json`: replace `noImplicitAny` + `strictNullChecks` with the `strict: true` umbrella, which also enables `strictFunctionTypes`, `strictBindCallApply`, `strictPropertyInitialization`, `noImplicitThis`, `alwaysStrict`, and `useUnknownInCatchVariables`
- 7 type errors surfaced and fixed:
  - `src/ObsidianIcalPlugin.ts` — `main` and `statusBar` use definite-assignment (`!`); `periodicSaveInterval` / `validationRefreshInterval` initialize to `null` at declaration
  - `src/SettingsManager.ts` — `settings` uses `!` with a comment about the `loadSettings()` lifecycle. Dropped the unused `plugin?: Plugin` optional path on the constructor (the only caller always passes one)
  - `src/SettingTab.ts` — replaced `error.message` access with an `error instanceof Error` guard so `useUnknownInCatchVariables` is happy

## Why
This was the highest single TS-quality lever the codebase was missing. Now any future contribution gets caught at compile time for null-deref, uninitialized fields, implicit `this`, or unsafe error access — no review-effort needed.

## Test plan
The fundamental "test" is `tsc -noEmit` itself succeeding under the new flags, plus all existing tests continuing to pass:
- [x] `bun run build` (includes `tsc -noEmit -skipLibCheck`) — clean
- [x] `bun run lint` — 0 errors
- [x] `bun run test` — Jest: 185/185 pass
- [x] `bun test` — bun native: 102/102 pass

Fixes #178