### PR TITLE
Move secrets to per-device localStorage

### DIFF
--- a/src/SecretStore.ts
+++ b/src/SecretStore.ts
@@ -1,0 +1,114 @@
+// Minimal Storage-shaped interface so the SecretStore can be tested without
+// jsdom or a real browser environment. The Obsidian renderer process exposes
+// window.localStorage which satisfies this interface natively.
+export interface StorageLike {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+}
+
+const PREFIX = 'obsidian-ical-plugin.';
+
+// Wraps a Storage-shaped backend with this plugin's key prefix so we don't
+// collide with other plugins, the Obsidian app itself, or future versions of
+// this plugin. Holds the two secrets (secretKey, githubPersonalAccessToken)
+// per-device rather than in the synced vault data.json.
+export class SecretStore {
+  private storage: StorageLike;
+
+  constructor(storage?: StorageLike) {
+    this.storage = storage ?? SecretStore.defaultStorage();
+  }
+
+  private static defaultStorage(): StorageLike {
+    // The Obsidian renderer process always has window.localStorage. In tests
+    // (or unusual host environments) we fall back to an in-memory shim so the
+    // plugin doesn't crash on access — secrets just won't persist.
+    // globalThis (rather than window) so this file is also importable from
+    // Node-based test environments where window is undefined; localStorage is
+    // a single per-process store either way.
+    // eslint-disable-next-line obsidianmd/no-global-this -- intentional: cross-env access
+    const ls = (globalThis as { localStorage?: StorageLike }).localStorage;
+    if (ls) return ls;
+    return new MemoryStorage();
+  }
+
+  get(name: string): string {
+    return this.storage.getItem(PREFIX + name) ?? '';
+  }
+
+  set(name: string, value: string): void {
+    if (value === '') {
+      this.storage.removeItem(PREFIX + name);
+    } else {
+      this.storage.setItem(PREFIX + name, value);
+    }
+  }
+
+  has(name: string): boolean {
+    return this.storage.getItem(PREFIX + name) !== null;
+  }
+
+  // Move a secret from a legacy on-disk location (data.json) into the secret
+  // store. Returns true when a migration actually happened so the caller can
+  // clear the legacy field. Idempotent: if the secret already exists in the
+  // store, the legacy value is ignored — the store wins.
+  migrateLegacy(name: string, legacyValue: string | undefined | null): boolean {
+    if (!legacyValue) return false;
+    if (this.has(name)) return false;
+    this.set(name, legacyValue);
+    return true;
+  }
+}
+
+// Names of the Settings fields that hold secrets. Kept in this module so the
+// list lives next to the SecretStore that owns them.
+export const SECRET_FIELD_NAMES = ['secretKey', 'githubPersonalAccessToken'] as const;
+export type SecretFieldName = (typeof SECRET_FIELD_NAMES)[number];
+
+// Carrier type for the migration helper: a plain object with the secret
+// fields as optional string properties. Matches the shape of Settings without
+// pulling in the whole interface (avoids a circular import).
+export type SecretFieldCarrier = {
+  [K in SecretFieldName]?: string;
+};
+
+// Pure helper used by SettingsManager. For each known secret field on the
+// settings object: copy the legacy value into the store (if non-empty and not
+// already migrated), then clear the field on the carrier. Returns true if at
+// least one field actually moved into the store on this call.
+//
+// Exported so it can be exercised in isolation without spinning up the
+// SettingsManager singleton + Plugin scaffolding.
+export function migrateSecretsToStore<T extends SecretFieldCarrier>(
+  carrier: T,
+  store: SecretStore,
+): boolean {
+  let migrated = false;
+  for (const name of SECRET_FIELD_NAMES) {
+    const legacyValue = carrier[name];
+    if (store.migrateLegacy(name, legacyValue)) {
+      migrated = true;
+    }
+    if (carrier[name] !== '') {
+      carrier[name] = '';
+    }
+  }
+  return migrated;
+}
+
+// In-memory fallback used in tests and any environment without a Storage
+// implementation. Not exported — consumers in tests inject their own
+// MemoryStorage via the constructor argument.
+class MemoryStorage implements StorageLike {
+  private data = new Map<string, string>();
+  getItem(key: string): string | null {
+    return this.data.has(key) ? this.data.get(key) ?? null : null;
+  }
+  setItem(key: string, value: string): void {
+    this.data.set(key, value);
+  }
+  removeItem(key: string): void {
+    this.data.delete(key);
+  }
+}

--- a/src/SettingsManager.ts
+++ b/src/SettingsManager.ts
@@ -1,6 +1,7 @@
 import { Plugin } from 'obsidian';
 import { log } from './Logger';
 import { DEFAULT_SETTINGS, Settings } from './Model/Settings';
+import { migrateSecretsToStore, SecretStore } from './SecretStore';
 
 // Settings class in instantiated using a singleton pattern
 class SettingsManager {
@@ -9,9 +10,11 @@ class SettingsManager {
   // anyone can read settings — strict-mode definite-assignment is safe here.
   private settings!: Settings;
   private plugin: Plugin;
+  private secretStore: SecretStore;
 
   private constructor(plugin: Plugin) {
     this.plugin = plugin;
+    this.secretStore = new SecretStore();
   }
 
   public static async createInstance(plugin: Plugin): Promise<SettingsManager> {
@@ -28,6 +31,14 @@ class SettingsManager {
   public async loadSettings() {
     log('Load settings');
     this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.plugin.loadData());
+
+    // One-shot migration: lift secret fields out of data.json into the
+    // SecretStore so they live in per-device localStorage instead of the
+    // synced/committable vault data file. Idempotent — if a secret already
+    // exists in the store, the legacy value is dropped.
+    if (migrateSecretsToStore(this.settings, this.secretStore)) {
+      log('Secrets migrated from data.json to SecretStore');
+    }
 
     // Because we may be applying new default settings to the settings that were loaded from the filesystem,
     // I think we should save these settings back to the filesystem.
@@ -49,12 +60,11 @@ class SettingsManager {
   }
 
   public get githubPersonalAccessToken(): string {
-    return this.settings.githubPersonalAccessToken;
+    return this.secretStore.get('githubPersonalAccessToken');
   }
 
   public set githubPersonalAccessToken(githubPersonalAccessToken: string) {
-    this.settings.githubPersonalAccessToken = githubPersonalAccessToken;
-    void this.saveSettings();
+    this.secretStore.set('githubPersonalAccessToken', githubPersonalAccessToken);
   }
 
   public get githubGistId(): string {
@@ -301,12 +311,11 @@ class SettingsManager {
   }
 
   public get secretKey(): string {
-    return this.settings.secretKey;
+    return this.secretStore.get('secretKey');
   }
 
   public set secretKey(secretKey: string) {
-    this.settings.secretKey = secretKey;
-    void this.saveSettings();
+    this.secretStore.set('secretKey', secretKey);
   }
 
   public get isSaveToWebEnabled(): boolean {

--- a/src/__tests__/SecretStore.test.ts
+++ b/src/__tests__/SecretStore.test.ts
@@ -1,0 +1,204 @@
+jest.mock('obsidian', () => ({ Plugin: class {} }));
+
+import { migrateSecretsToStore, SecretStore, StorageLike } from '../SecretStore';
+
+function makeFakeStorage(): StorageLike & { dump: () => Record<string, string> } {
+  const data = new Map<string, string>();
+  return {
+    getItem(key: string): string | null {
+      return data.has(key) ? data.get(key) ?? null : null;
+    },
+    setItem(key: string, value: string): void {
+      data.set(key, value);
+    },
+    removeItem(key: string): void {
+      data.delete(key);
+    },
+    dump(): Record<string, string> {
+      return Object.fromEntries(data);
+    },
+  };
+}
+
+describe('SecretStore', () => {
+  it('returns empty string for a missing name', () => {
+    const store = new SecretStore(makeFakeStorage());
+    expect(store.get('secretKey')).toBe('');
+  });
+
+  it('round-trips a value through set/get', () => {
+    const store = new SecretStore(makeFakeStorage());
+    store.set('secretKey', 'abc123');
+    expect(store.get('secretKey')).toBe('abc123');
+  });
+
+  it('applies the plugin prefix to the underlying storage key', () => {
+    const storage = makeFakeStorage();
+    const store = new SecretStore(storage);
+    store.set('secretKey', 'abc123');
+    expect(storage.dump()).toEqual({ 'obsidian-ical-plugin.secretKey': 'abc123' });
+  });
+
+  it('removes the underlying key when set to empty string', () => {
+    const storage = makeFakeStorage();
+    const store = new SecretStore(storage);
+    store.set('secretKey', 'abc123');
+    store.set('secretKey', '');
+    expect(storage.dump()).toEqual({});
+    expect(store.get('secretKey')).toBe('');
+  });
+
+  it('has() reports presence accurately', () => {
+    const store = new SecretStore(makeFakeStorage());
+    expect(store.has('secretKey')).toBe(false);
+    store.set('secretKey', 'abc');
+    expect(store.has('secretKey')).toBe(true);
+    store.set('secretKey', '');
+    expect(store.has('secretKey')).toBe(false);
+  });
+
+  it('isolates separate names', () => {
+    const store = new SecretStore(makeFakeStorage());
+    store.set('secretKey', 'sk');
+    store.set('githubPersonalAccessToken', 'gp');
+    expect(store.get('secretKey')).toBe('sk');
+    expect(store.get('githubPersonalAccessToken')).toBe('gp');
+  });
+
+  describe('migrateLegacy', () => {
+    it('moves a legacy value into the store when nothing is present', () => {
+      const store = new SecretStore(makeFakeStorage());
+      const moved = store.migrateLegacy('secretKey', 'legacy-value');
+      expect(moved).toBe(true);
+      expect(store.get('secretKey')).toBe('legacy-value');
+    });
+
+    it('returns false and does nothing when legacy value is empty', () => {
+      const store = new SecretStore(makeFakeStorage());
+      expect(store.migrateLegacy('secretKey', '')).toBe(false);
+      expect(store.migrateLegacy('secretKey', undefined)).toBe(false);
+      expect(store.migrateLegacy('secretKey', null)).toBe(false);
+      expect(store.has('secretKey')).toBe(false);
+    });
+
+    it('returns false and preserves the existing store value when already migrated', () => {
+      const store = new SecretStore(makeFakeStorage());
+      store.set('secretKey', 'existing');
+      const moved = store.migrateLegacy('secretKey', 'legacy-attempt');
+      expect(moved).toBe(false);
+      expect(store.get('secretKey')).toBe('existing');
+    });
+
+    it('is idempotent — calling twice in a row only migrates the first time', () => {
+      const store = new SecretStore(makeFakeStorage());
+      expect(store.migrateLegacy('secretKey', 'legacy')).toBe(true);
+      expect(store.migrateLegacy('secretKey', 'legacy')).toBe(false);
+      expect(store.get('secretKey')).toBe('legacy');
+    });
+  });
+
+  describe('default storage fallback', () => {
+    it('does not throw when constructed without an explicit storage', () => {
+      // In the jest 'node' test env globalThis.localStorage is undefined, so
+      // the SecretStore falls back to its in-memory shim. The point of this
+      // test is just to confirm the constructor doesn't blow up under that
+      // condition.
+      const store = new SecretStore();
+      expect(store.get('secretKey')).toBe('');
+      store.set('secretKey', 'hello');
+      expect(store.get('secretKey')).toBe('hello');
+    });
+  });
+});
+
+describe('migrateSecretsToStore', () => {
+  it('moves both legacy secret values into the store and clears the carrier', () => {
+    const store = new SecretStore(makeFakeStorage());
+    const carrier = {
+      secretKey: 'legacy-sk',
+      githubPersonalAccessToken: 'legacy-pat',
+      // unrelated fields are preserved
+      otherField: 'kept',
+    } as unknown as { secretKey?: string; githubPersonalAccessToken?: string; otherField?: string };
+
+    const migrated = migrateSecretsToStore(carrier, store);
+
+    expect(migrated).toBe(true);
+    expect(store.get('secretKey')).toBe('legacy-sk');
+    expect(store.get('githubPersonalAccessToken')).toBe('legacy-pat');
+    expect(carrier.secretKey).toBe('');
+    expect(carrier.githubPersonalAccessToken).toBe('');
+    expect(carrier.otherField).toBe('kept');
+  });
+
+  it('is idempotent — running twice does not overwrite or re-migrate', () => {
+    const storage = makeFakeStorage();
+    const store = new SecretStore(storage);
+    const carrier = { secretKey: 'legacy-sk', githubPersonalAccessToken: '' } as { secretKey?: string; githubPersonalAccessToken?: string };
+
+    const firstRun = migrateSecretsToStore(carrier, store);
+    const secondRun = migrateSecretsToStore(carrier, store);
+
+    expect(firstRun).toBe(true);
+    expect(secondRun).toBe(false);
+    expect(store.get('secretKey')).toBe('legacy-sk');
+    expect(carrier.secretKey).toBe('');
+  });
+
+  it('returns false and changes nothing when there is no legacy data', () => {
+    const storage = makeFakeStorage();
+    const store = new SecretStore(storage);
+    const carrier = { secretKey: '', githubPersonalAccessToken: '' } as { secretKey?: string; githubPersonalAccessToken?: string };
+
+    const migrated = migrateSecretsToStore(carrier, store);
+
+    expect(migrated).toBe(false);
+    expect(store.has('secretKey')).toBe(false);
+    expect(store.has('githubPersonalAccessToken')).toBe(false);
+    expect(storage.dump()).toEqual({});
+  });
+
+  it('preserves the existing store value when the legacy carrier has a different one', () => {
+    const store = new SecretStore(makeFakeStorage());
+    store.set('secretKey', 'already-in-store');
+    const carrier = { secretKey: 'leftover-on-disk' } as { secretKey?: string; githubPersonalAccessToken?: string };
+
+    const migrated = migrateSecretsToStore(carrier, store);
+
+    expect(migrated).toBe(false);
+    expect(store.get('secretKey')).toBe('already-in-store');
+    // Carrier is still cleared even though no migration happened — once a
+    // secret lives in the store, the disk copy is no longer the source of
+    // truth.
+    expect(carrier.secretKey).toBe('');
+  });
+
+  it('clears only the secret fields, leaves unrelated fields untouched', () => {
+    const store = new SecretStore(makeFakeStorage());
+    const carrier = {
+      secretKey: 'sk',
+      githubPersonalAccessToken: 'pat',
+      filename: 'obsidian.ics',
+      isDebug: true,
+      periodicSaveInterval: 5,
+    } as Record<string, unknown>;
+
+    migrateSecretsToStore(carrier as { secretKey?: string; githubPersonalAccessToken?: string }, store);
+
+    expect(carrier.filename).toBe('obsidian.ics');
+    expect(carrier.isDebug).toBe(true);
+    expect(carrier.periodicSaveInterval).toBe(5);
+  });
+
+  it('migrates only one field when only one has a legacy value', () => {
+    const store = new SecretStore(makeFakeStorage());
+    const carrier = { secretKey: '', githubPersonalAccessToken: 'just-the-pat' } as { secretKey?: string; githubPersonalAccessToken?: string };
+
+    const migrated = migrateSecretsToStore(carrier, store);
+
+    expect(migrated).toBe(true);
+    expect(store.has('secretKey')).toBe(false);
+    expect(store.get('githubPersonalAccessToken')).toBe('just-the-pat');
+    expect(carrier.githubPersonalAccessToken).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary
- New `SecretStore` class wrapping a `StorageLike` backend (`localStorage` in the Obsidian renderer, in-memory shim elsewhere) with this plugin's key prefix
- New `migrateSecretsToStore` pure helper that copies legacy values out of the settings object into the store and clears the fields. Idempotent
- `SettingsManager` runs the migration on every `loadSettings()`. The `secretKey` and `githubPersonalAccessToken` getters/setters now read/write through `SecretStore` — `Settings` holds empty strings for those fields going forward
- `saveData()` still runs after migration, so `data.json` is cleaned up on the next save

## Why
Both secrets used to live in `data.json`:
- Included in Obsidian Sync
- Committable if the vault is in git
- Readable by other plugins via the vault adapter

The API key gates a paid subscription; the GitHub PAT can read/write any of the user's gists (and depending on scope, more). Moving them to per-device `localStorage` removes them from any of those exfiltration paths.

## Multi-device caveat ⚠️
Users running Obsidian Sync across multiple devices will need to re-enter their secrets on **each device** the first time the migrated plugin loads there. This is by design — after Device A migrates and clears `data.json`, Device B receives the empty values via sync and has nothing to migrate. The store is per-device.

The settings UI already shows the empty field state so users will notice immediately. They re-enter once; subsequent loads on that device just read from `localStorage`.

## Risk & testing
The original issue flagged this as the highest-risk PR in the batch. Mitigations:
- Migration is idempotent: re-running it on already-migrated data is a no-op
- Store wins over legacy: a value already in the store never gets overwritten by an out-of-sync `data.json`
- `localStorage` unavailability degrades to in-memory rather than crashing (renderer always has it; the fallback is for test environments)
- All field clearing happens **after** the value has been written into the store

## Test plan
- [x] `bun run lint` — 0 errors
- [x] `bun run test` — Jest: 202/202 pass (17 new tests covering `SecretStore` round-trip, prefix, removal, has, isolation, default fallback, `migrateLegacy` empty/idempotent/existing, and `migrateSecretsToStore` both-fields/idempotent/no-op/preserves-existing/leaves-unrelated/partial)
- [x] `bun test` — bun native: 102/102 pass
- [x] `bun run build` — clean
- [ ] **Manual smoke before merging**: install the build into a real Obsidian vault that has existing `secretKey` / `githubPersonalAccessToken` in `data.json`, confirm:
  - Plugin loads without errors
  - Secrets are still active (member status shows, gist saves still work)
  - `data.json` no longer contains the secret values
  - DevTools `localStorage` shows `obsidian-ical-plugin.secretKey` and `obsidian-ical-plugin.githubPersonalAccessToken`

Recommend manual verification before merging because the migration touches user-saved credentials.

Fixes #179