### PR TITLE
Construct fresh ApiClient per access so secretKey changes propagate

### DIFF
--- a/src/Main.ts
+++ b/src/Main.ts
@@ -1,7 +1,7 @@
 import { App } from 'obsidian';
 import { FileClient } from './FileClient';
 import { GithubClient } from './GithubClient';
-import { ApiClient } from './ApiClient';
+import { ApiClient, apiClient } from './ApiClient';
 import { IcalService } from './IcalService';
 import { log } from './Logger';
 import { Task } from './Model/Task';
@@ -16,7 +16,6 @@ export class Main {
   iCalService: IcalService;
   githubClient: GithubClient;
   fileClient: FileClient;
-  apiClient: ApiClient;
   tasks: Task[];
   taskFinder: TaskFinder;
 
@@ -25,10 +24,17 @@ export class Main {
     this.statusBar = statusBar;
     this.iCalService = new IcalService();
     this.githubClient = new GithubClient();
-    this.apiClient = new ApiClient(app.vault.getName(), settings.secretKey);
     this.fileClient = new FileClient(this.app.vault);
     this.tasks = [];
     this.taskFinder = new TaskFinder(this.app.vault);
+  }
+
+  // Construct an ApiClient on demand so each call reads the current
+  // settings.secretKey. A long-lived snapshot would go stale the moment the
+  // user updates their key in Settings; the ValidationCache singleton handles
+  // caching across instances so there's no per-call performance cost.
+  get apiClient(): ApiClient {
+    return apiClient(this.app.vault.getName(), settings.secretKey);
   }
 
   async start() {

--- a/src/__tests__/Main.test.ts
+++ b/src/__tests__/Main.test.ts
@@ -1,0 +1,90 @@
+jest.mock('obsidian', () => ({
+  moment: jest.fn(),
+  Plugin: class {},
+  TFile: class {},
+}));
+
+// @octokit/rest is ESM and Jest's CJS pipeline can't parse it. The Main
+// constructor instantiates GithubClient which imports it — mock it out so
+// these tests don't trip on the import.
+jest.mock('@octokit/rest', () => ({ Octokit: class {} }));
+
+const mockSettings = {
+  secretKey: '',
+  // The rest of the fields aren't used by the apiClient getter but are
+  // present to keep TypeScript happy if anything else dereferences settings.
+  includeEventsOrTodos: 'EventsOnly',
+  howToProcessMultipleDates: 'PreferDueDate',
+  isIncludeLinkInDescription: false,
+  isIncludeLocation: true,
+  isOnlyTasksWithoutDatesAreTodos: true,
+};
+
+jest.mock('../SettingsManager', () => ({
+  settings: mockSettings,
+}));
+
+import { Main } from '../Main';
+import { ApiClient } from '../ApiClient';
+
+function makeMain(): Main {
+  const fakeApp = {
+    vault: {
+      getName: () => 'test-vault',
+      getMarkdownFiles: () => [],
+      cachedRead: jest.fn(),
+    },
+    metadataCache: {
+      getFileCache: jest.fn(),
+    },
+  };
+  const fakeStatusBar = {
+    scanning: jest.fn(),
+    building: jest.fn(),
+    saving: jest.fn(),
+    synced: jest.fn(),
+    scanError: jest.fn(),
+    saveError: jest.fn(),
+  };
+  return new Main(fakeApp as never, fakeStatusBar as never);
+}
+
+describe('Main.apiClient getter', () => {
+  beforeEach(() => {
+    mockSettings.secretKey = '';
+  });
+
+  it('returns a fresh ApiClient instance each access', () => {
+    const main = makeMain();
+    mockSettings.secretKey = 'a'.repeat(32);
+
+    const a = main.apiClient;
+    const b = main.apiClient;
+
+    expect(a).toBeInstanceOf(ApiClient);
+    expect(b).toBeInstanceOf(ApiClient);
+    expect(a).not.toBe(b);
+  });
+
+  it('picks up the current settings.secretKey on every access', () => {
+    const main = makeMain();
+
+    mockSettings.secretKey = 'a'.repeat(32);
+    expect(main.apiClient.secretKey).toBe('a'.repeat(32));
+
+    // Simulate the user updating their key in the Settings UI.
+    mockSettings.secretKey = 'b'.repeat(32);
+    expect(main.apiClient.secretKey).toBe('b'.repeat(32));
+  });
+
+  it('uses the vault name from the app', () => {
+    const main = makeMain();
+    mockSettings.secretKey = 'x'.repeat(32);
+    expect(main.apiClient.vaultName).toBe('test-vault');
+  });
+
+  it('reads an empty key when none has been set', () => {
+    const main = makeMain();
+    expect(main.apiClient.secretKey).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary
- Replace `Main.apiClient` field with a getter that calls the `apiClient()` factory using the current `settings.secretKey` on each access
- Removes the constructor-time snapshot that made stale-key bugs invisible until plugin reload
- All existing call sites (`this.main.apiClient.isActive(...)`, `this.apiClient.save(...)`) work unchanged — now backed by a fresh instance

## Why
`Main.apiClient` was assigned once in the constructor and reused for the lifetime of the plugin (periodic save + the 5-min validation refresh interval). If a user changed their secret key in Settings, the snapshot stayed stale until reload — save-to-web returned 401 and the validation refresh cached against the wrong key.

`ValidationCache` is a singleton keyed by secretKey so caching still works across fresh instances; no perf cost.

## Test plan
- [x] 4 new unit tests in `src/__tests__/Main.test.ts` covering the regression specifically: changing `settings.secretKey` between two accesses of `main.apiClient` is reflected in the second instance
- [x] `bun run lint` — 0 errors
- [x] `bun run test` — Jest: 206/206 pass (4 new tests)
- [x] `bun test` — bun native: 102/102 pass
- [x] `bun run build` — clean

Fixes #186