### PR TITLE
Show Notice when calendar Refresh button fails

### DIFF
--- a/src/SettingTab.ts
+++ b/src/SettingTab.ts
@@ -3,6 +3,7 @@ import {
   ButtonComponent,
   DropdownComponent,
   normalizePath,
+  Notice,
   PluginSettingTab,
   Setting,
   TextComponent,
@@ -315,6 +316,12 @@ export class SettingTab extends PluginSettingTab {
                 if (info) {
                   this.calendarUrl = info.url;
                   this.calendarUpdatedAt = info.updatedAt;
+                } else {
+                  // forceRefetch returns null for both 'no calendar yet' and
+                  // network/auth errors. Surface this so the user knows the
+                  // refresh didn't pick up anything — without a Notice the
+                  // button just snaps back and looks like a no-op.
+                  new Notice('Couldn\'t refresh calendar info. Check your secret key, network, and that you\'ve saved at least once.');
                 }
                 this.display();
               });


### PR DESCRIPTION
## Summary
- When `CalendarInfoFetcher.forceRefetch()` returns null (network error or 'no calendar yet'), the Refresh button on the Calendar URL row now surfaces an Obsidian Notice instead of silently snapping back
- Stale URL is deliberately preserved on screen — it's still usable for transient network failures, and the Notice explains why the refresh didn't pick anything new

## Why
Before this change, a failed Refresh click looked identical to a no-op: the button blipped through '⏳ Refreshing…' and back to '🔄 Refresh' with the same URL still showing. No feedback to the user.

## Test plan
- [x] `bun run lint` — 0 errors
- [x] `bun run test` — Jest: 206/206 pass (CalendarInfoFetcher's null-return paths for not-found + thrown error are already covered)
- [x] `bun test` — bun native: 102/102 pass
- [x] `bun run build` — clean
- [ ] Manual: with an invalid key, click Refresh → confirm Notice appears

Note: the SettingTab integration is a 2-line wiring change. The high-risk behavior (`forceRefetch` returning null) is fully covered at the `CalendarInfoFetcher` layer (8 tests in `src/__tests__/CalendarInfoFetcher.test.ts`).

Fixes #187