### PR TITLE
Add one-time Notice for the new ignoreCancelledTasks default

### DIFF
--- a/src/CancelledTasksNotice.ts
+++ b/src/CancelledTasksNotice.ts
@@ -1,0 +1,30 @@
+// One-time announcement that the ignoreCancelledTasks default flipped to true.
+// Existing users upgrading to the release containing PR #180 would otherwise
+// see cancelled tasks silently disappear from their calendars; this Notice
+// makes the behaviour change visible and tells them how to revert.
+//
+// The decision logic is split out so it can be unit-tested without
+// instantiating Obsidian's Notice class or the SettingsManager singleton.
+
+export interface CancelledTasksNoticeContext {
+  // True if the user has already seen the notice in a previous session.
+  hasSeen: boolean;
+  // Persists hasSeen=true so the notice doesn't fire again.
+  markSeen: () => void;
+  // Displays the message — usually `new Notice(msg, timeoutMs)` in production.
+  showNotice: (message: string) => void;
+}
+
+export const CANCELLED_TASKS_NOTICE_MESSAGE =
+  'obsidian-to-ical: cancelled tasks (- [-]) are now hidden from your calendar by default. ' +
+  'You can re-enable them in Settings → "Ignore cancelled tasks?".';
+
+// Show the one-time notice if it hasn't been shown yet. Returns true when the
+// notice fired this call, false when it was suppressed. Always marks-seen
+// after firing so subsequent calls become no-ops even across sessions.
+export function maybeShowCancelledTasksNotice(ctx: CancelledTasksNoticeContext): boolean {
+  if (ctx.hasSeen) return false;
+  ctx.showNotice(CANCELLED_TASKS_NOTICE_MESSAGE);
+  ctx.markSeen();
+  return true;
+}

--- a/src/Model/Settings.ts
+++ b/src/Model/Settings.ts
@@ -33,6 +33,7 @@ export interface Settings {
   howToParseInternalLinks: string;
   ignoreCompletedTasks: boolean;
   ignoreCancelledTasks: boolean;
+  hasSeenCancelledTasksNotice: boolean;
   isDebug: boolean;
   includeEventsOrTodos: string;
   isOnlyTasksWithoutDatesAreTodos: boolean;
@@ -66,6 +67,7 @@ export const DEFAULT_SETTINGS: Settings = {
   howToParseInternalLinks: 'DoNotModifyThem', // HOW_TO_PARSE_INTERNAL_LINKS.DoNotModifyThem,
   ignoreCompletedTasks: false,
   ignoreCancelledTasks: true,
+  hasSeenCancelledTasksNotice: false,
   isDebug: false,
   includeEventsOrTodos: 'EventsOnly', // INCLUDE_EVENTS_OR_TODOS.EventsOnly
   isOnlyTasksWithoutDatesAreTodos: true,

--- a/src/ObsidianIcalPlugin.ts
+++ b/src/ObsidianIcalPlugin.ts
@@ -1,9 +1,10 @@
-import { Plugin } from 'obsidian';
+import { Notice, Plugin } from 'obsidian';
 import { Main } from 'src/Main';
 import { log, logger } from './Logger';
 import { SettingTab } from './SettingTab';
 import { initSettingsManager, settings } from './SettingsManager';
 import { StatusBar } from './StatusBar';
+import { maybeShowCancelledTasksNotice } from './CancelledTasksNotice';
 
 export default class ObsidianIcalPlugin extends Plugin {
   main!: Main;
@@ -18,6 +19,14 @@ export default class ObsidianIcalPlugin extends Plugin {
     logger(settings.isDebug);
 
     log('SettingsManager and Logger initialised');
+
+    // One-time announcement of the ignoreCancelledTasks=true default. After
+    // this fires once it's a no-op for the rest of the plugin's lifetime.
+    maybeShowCancelledTasksNotice({
+      hasSeen: settings.hasSeenCancelledTasksNotice,
+      markSeen: () => { settings.hasSeenCancelledTasksNotice = true; },
+      showNotice: (msg) => { new Notice(msg, 15000); },
+    });
 
     // // This creates an icon in the left ribbon.
     // const ribbonIconEl = this.addRibbonIcon(

--- a/src/SettingsManager.ts
+++ b/src/SettingsManager.ts
@@ -184,6 +184,15 @@ class SettingsManager {
     void this.saveSettings();
   }
 
+  public get hasSeenCancelledTasksNotice(): boolean {
+    return this.settings.hasSeenCancelledTasksNotice;
+  }
+
+  public set hasSeenCancelledTasksNotice(hasSeenCancelledTasksNotice: boolean) {
+    this.settings.hasSeenCancelledTasksNotice = hasSeenCancelledTasksNotice;
+    void this.saveSettings();
+  }
+
   public get isDebug(): boolean {
     return this.settings.isDebug;
   }

--- a/src/__tests__/CancelledTasksNotice.test.ts
+++ b/src/__tests__/CancelledTasksNotice.test.ts
@@ -1,0 +1,66 @@
+jest.mock('obsidian', () => ({ Plugin: class {} }));
+
+import {
+  CANCELLED_TASKS_NOTICE_MESSAGE,
+  maybeShowCancelledTasksNotice,
+  CancelledTasksNoticeContext,
+} from '../CancelledTasksNotice';
+
+function makeCtx(initialHasSeen: boolean): CancelledTasksNoticeContext & {
+  shown: string[];
+  hasSeen: boolean;
+} {
+  const shown: string[] = [];
+  let seen = initialHasSeen;
+  return {
+    get hasSeen() {
+      return seen;
+    },
+    set hasSeen(v: boolean) {
+      seen = v;
+    },
+    markSeen() {
+      seen = true;
+    },
+    showNotice(msg: string) {
+      shown.push(msg);
+    },
+    shown,
+  };
+}
+
+describe('maybeShowCancelledTasksNotice', () => {
+  it('shows the notice and marks seen when hasSeen is false', () => {
+    const ctx = makeCtx(false);
+    const fired = maybeShowCancelledTasksNotice(ctx);
+
+    expect(fired).toBe(true);
+    expect(ctx.shown).toEqual([CANCELLED_TASKS_NOTICE_MESSAGE]);
+    expect(ctx.hasSeen).toBe(true);
+  });
+
+  it('does not show the notice when hasSeen is already true', () => {
+    const ctx = makeCtx(true);
+    const fired = maybeShowCancelledTasksNotice(ctx);
+
+    expect(fired).toBe(false);
+    expect(ctx.shown).toEqual([]);
+    expect(ctx.hasSeen).toBe(true);
+  });
+
+  it('is idempotent — second call after first does not show again', () => {
+    const ctx = makeCtx(false);
+    maybeShowCancelledTasksNotice(ctx);
+    const secondFired = maybeShowCancelledTasksNotice(ctx);
+
+    expect(secondFired).toBe(false);
+    expect(ctx.shown).toEqual([CANCELLED_TASKS_NOTICE_MESSAGE]);
+  });
+
+  it('the message mentions the new default behaviour and where to change it', () => {
+    expect(CANCELLED_TASKS_NOTICE_MESSAGE).toContain('cancelled tasks');
+    expect(CANCELLED_TASKS_NOTICE_MESSAGE).toContain('hidden');
+    expect(CANCELLED_TASKS_NOTICE_MESSAGE).toContain('Settings');
+    expect(CANCELLED_TASKS_NOTICE_MESSAGE).toContain('Ignore cancelled tasks');
+  });
+});

--- a/src/__tests__/Settings.test.ts
+++ b/src/__tests__/Settings.test.ts
@@ -24,6 +24,7 @@ describe('Settings', () => {
       expect(DEFAULT_SETTINGS).toHaveProperty('howToParseInternalLinks');
       expect(DEFAULT_SETTINGS).toHaveProperty('ignoreCompletedTasks');
       expect(DEFAULT_SETTINGS).toHaveProperty('ignoreCancelledTasks');
+      expect(DEFAULT_SETTINGS).toHaveProperty('hasSeenCancelledTasksNotice');
       expect(DEFAULT_SETTINGS).toHaveProperty('isDebug');
       expect(DEFAULT_SETTINGS).toHaveProperty('includeEventsOrTodos');
       expect(DEFAULT_SETTINGS).toHaveProperty('isOnlyTasksWithoutDatesAreTodos');
@@ -51,6 +52,7 @@ describe('Settings', () => {
       expect(DEFAULT_SETTINGS.saveFileExtension).toBe('.ical');
       expect(DEFAULT_SETTINGS.ignoreCompletedTasks).toBe(false);
       expect(DEFAULT_SETTINGS.ignoreCancelledTasks).toBe(true);
+      expect(DEFAULT_SETTINGS.hasSeenCancelledTasksNotice).toBe(false);
       expect(DEFAULT_SETTINGS.isDebug).toBe(false);
       expect(DEFAULT_SETTINGS.includeEventsOrTodos).toBe('EventsOnly');
       expect(DEFAULT_SETTINGS.isOnlyTasksWithoutDatesAreTodos).toBe(true);


### PR DESCRIPTION
## Summary
- New `hasSeenCancelledTasksNotice` setting (default `false`), persisted via existing Settings/data.json flow
- New `maybeShowCancelledTasksNotice(ctx)` helper in `src/CancelledTasksNotice.ts` — pure decision logic with an injected `NoticeContext` (hasSeen / markSeen / showNotice) so it's unit-testable without touching Obsidian
- Wired into `ObsidianIcalPlugin.onload` right after the settings load. Uses `new Notice(msg, 15000)` so the announcement stays on screen long enough to read
- Idempotent — after the first fire, `hasSeenCancelledTasksNotice` flips to true and persists; subsequent loads are no-ops

## Why
PR #180 flipped the default to `ignoreCancelledTasks=true`. Without this PR, existing users would silently see cancelled (`- [-]`) tasks vanish from their calendars on upgrade. The notice tells them what happened and where to toggle it back.

## Test plan
- [x] 4 new tests in `src/__tests__/CancelledTasksNotice.test.ts` covering fire-once, skip-when-seen, idempotency, and message content
- [x] 2 additions to `src/__tests__/Settings.test.ts` asserting the new field and its `false` default
- [x] `bun run lint` — 0 errors
- [x] `bun run test` — Jest: 210/210 pass
- [x] `bun test` — bun native: 102/102 pass
- [x] `bun run build` — clean
- [ ] Manual: install the build into a vault that doesn't have `hasSeenCancelledTasksNotice` in `data.json` → confirm Notice appears once → reload plugin → confirm Notice does NOT appear

Fixes #188