### PR TITLE
Drop change-announcement wording from cancelled-tasks Notice

### DIFF
--- a/src/CancelledTasksNotice.ts
+++ b/src/CancelledTasksNotice.ts
@@ -16,7 +16,7 @@ export interface CancelledTasksNoticeContext {
 }
 
 export const CANCELLED_TASKS_NOTICE_MESSAGE =
-  'obsidian-to-ical: cancelled tasks (- [-]) are now hidden from your calendar by default. ' +
+  'obsidian-to-ical: cancelled tasks (- [-]) are hidden from your calendar by default. ' +
   'You can re-enable them in Settings → "Ignore cancelled tasks?".';
 
 // Show the one-time notice if it hasn't been shown yet. Returns true when the

--- a/src/__tests__/CancelledTasksNotice.test.ts
+++ b/src/__tests__/CancelledTasksNotice.test.ts
@@ -63,4 +63,9 @@ describe('maybeShowCancelledTasksNotice', () => {
     expect(CANCELLED_TASKS_NOTICE_MESSAGE).toContain('Settings');
     expect(CANCELLED_TASKS_NOTICE_MESSAGE).toContain('Ignore cancelled tasks');
   });
+
+  it('does not use change-announcement wording so it reads cleanly for fresh installs', () => {
+    // 'now' implies a 'before' that brand-new users have no context for.
+    expect(CANCELLED_TASKS_NOTICE_MESSAGE).not.toMatch(/\bnow\b/i);
+  });
 });


### PR DESCRIPTION
## Summary
- `CANCELLED_TASKS_NOTICE_MESSAGE`: 'are now hidden' → 'are hidden' so the sentence reads naturally for both upgraders and fresh installs
- New regression test asserts the message doesn't contain a standalone 'now'

## Why
For users with no prior `data.json`, the Notice still fires (since `hasSeenCancelledTasksNotice` defaults to false). The original "now" implies a behaviour change relative to a "before" that fresh installs don't have.

## Test plan
- [x] `bun run lint` — 0 errors
- [x] `bun run test` — Jest: 211/211 pass (1 new regression test)
- [x] `bun test` — bun native: 102/102 pass
- [x] `bun run build` — clean

Fixes #192