### PR TITLE
Clear stale URL on Refresh failure and distinguish not-found from error

### DIFF
--- a/src/CalendarInfoFetcher.ts
+++ b/src/CalendarInfoFetcher.ts
@@ -5,6 +5,12 @@ export interface CalendarInfo {
   updatedAt: string;
 }
 
+// Tracks why the last fetch attempt returned what it did, so callers (e.g.
+// the SettingTab Refresh button) can distinguish "the server says no
+// calendar exists" from "we couldn't reach the server" — those need
+// different Notice messages.
+export type FetchOutcome = 'idle' | 'found' | 'not-found' | 'error';
+
 // Gate around ApiClient.getCalendar() so the Settings tab only hits the
 // network once per validation cycle. Previously getCalendar() fired on every
 // SettingTab.display() re-render — which happens for every toggle click —
@@ -14,10 +20,12 @@ export class CalendarInfoFetcher {
   private hasAttemptedFetch: boolean = false;
   private isFetching: boolean = false;
   private cached: CalendarInfo | null = null;
+  private outcome: FetchOutcome = 'idle';
 
   reset(): void {
     this.hasAttemptedFetch = false;
     this.cached = null;
+    this.outcome = 'idle';
   }
 
   get info(): CalendarInfo | null {
@@ -26,6 +34,10 @@ export class CalendarInfoFetcher {
 
   get hasAttempted(): boolean {
     return this.hasAttemptedFetch;
+  }
+
+  get lastOutcome(): FetchOutcome {
+    return this.outcome;
   }
 
   async fetchOnce(client: ApiClient): Promise<CalendarInfo | null> {
@@ -49,13 +61,16 @@ export class CalendarInfoFetcher {
       const response = await client.getCalendar();
       if (response.found && response.url && response.updatedAt) {
         this.cached = { url: response.url, updatedAt: response.updatedAt };
+        this.outcome = 'found';
       } else {
         this.cached = null;
+        this.outcome = 'not-found';
       }
     } catch {
-      // Swallow — calendar URL just won't appear. The validation status is
-      // owned by the separate ApiClient.isActive cache.
+      // The validation status is owned by the separate ApiClient.isActive
+      // cache; failures here only affect the calendar URL display.
       this.cached = null;
+      this.outcome = 'error';
     } finally {
       this.isFetching = false;
       this.hasAttemptedFetch = true;

--- a/src/SettingTab.ts
+++ b/src/SettingTab.ts
@@ -317,11 +317,17 @@ export class SettingTab extends PluginSettingTab {
                   this.calendarUrl = info.url;
                   this.calendarUpdatedAt = info.updatedAt;
                 } else {
-                  // forceRefetch returns null for both 'no calendar yet' and
-                  // network/auth errors. Surface this so the user knows the
-                  // refresh didn't pick up anything — without a Notice the
-                  // button just snaps back and looks like a no-op.
-                  new Notice('Couldn\'t refresh calendar info. Check your secret key, network, and that you\'ve saved at least once.');
+                  // Refresh failed. Clear the on-screen URL so the user isn't
+                  // shown a stale link alongside a Notice that says they
+                  // couldn't refresh it — that combination is more confusing
+                  // than useful. The Refresh button stays available for retry.
+                  this.calendarUrl = null;
+                  this.calendarUpdatedAt = null;
+                  if (this.calendarFetcher.lastOutcome === 'not-found') {
+                    new Notice('No calendar found yet. Enable "Save calendar to the web" and trigger a save to create one.');
+                  } else {
+                    new Notice('Couldn\'t refresh calendar info. Check your secret key and network connection.');
+                  }
                 }
                 this.display();
               });

--- a/src/__tests__/CalendarInfoFetcher.test.ts
+++ b/src/__tests__/CalendarInfoFetcher.test.ts
@@ -135,3 +135,73 @@ describe('CalendarInfoFetcher', () => {
     expect(getCalendar).toHaveBeenCalledTimes(2);
   });
 });
+
+describe('CalendarInfoFetcher.lastOutcome', () => {
+  it('is idle before any fetch attempt', () => {
+    const fetcher = new CalendarInfoFetcher();
+    expect(fetcher.lastOutcome).toBe('idle');
+  });
+
+  it('is found after a successful fetch', async () => {
+    const { client } = makeClient([
+      { found: true, url: 'https://x.com/cal', updatedAt: '2026-05-27T10:00:00Z' },
+    ]);
+    const fetcher = new CalendarInfoFetcher();
+    await fetcher.fetchOnce(client);
+    expect(fetcher.lastOutcome).toBe('found');
+  });
+
+  it('is not-found when the server returns no calendar', async () => {
+    const { client } = makeClient([{ found: false, url: null, updatedAt: null }]);
+    const fetcher = new CalendarInfoFetcher();
+    await fetcher.fetchOnce(client);
+    expect(fetcher.lastOutcome).toBe('not-found');
+  });
+
+  it('is error when getCalendar throws', async () => {
+    const { client } = makeClient([new Error('network down')]);
+    const fetcher = new CalendarInfoFetcher();
+    await fetcher.fetchOnce(client);
+    expect(fetcher.lastOutcome).toBe('error');
+  });
+
+  it('resets to idle on reset()', async () => {
+    const { client } = makeClient([
+      { found: true, url: 'https://x.com/cal', updatedAt: '2026-05-27T10:00:00Z' },
+    ]);
+    const fetcher = new CalendarInfoFetcher();
+    await fetcher.fetchOnce(client);
+    expect(fetcher.lastOutcome).toBe('found');
+    fetcher.reset();
+    expect(fetcher.lastOutcome).toBe('idle');
+  });
+
+  it('forceRefetch updates outcome to reflect the new result', async () => {
+    const { client } = makeClient([
+      { found: true, url: 'https://x.com/cal', updatedAt: '2026-05-27T10:00:00Z' },
+      { found: false, url: null, updatedAt: null },
+    ]);
+    const fetcher = new CalendarInfoFetcher();
+
+    await fetcher.fetchOnce(client);
+    expect(fetcher.lastOutcome).toBe('found');
+
+    await fetcher.forceRefetch(client);
+    expect(fetcher.lastOutcome).toBe('not-found');
+    expect(fetcher.info).toBeNull();
+  });
+
+  it('an error after a previous success replaces the outcome', async () => {
+    const { client } = makeClient([
+      { found: true, url: 'https://x.com/cal', updatedAt: '2026-05-27T10:00:00Z' },
+      new Error('network down'),
+    ]);
+    const fetcher = new CalendarInfoFetcher();
+
+    await fetcher.fetchOnce(client);
+    expect(fetcher.lastOutcome).toBe('found');
+
+    await fetcher.forceRefetch(client);
+    expect(fetcher.lastOutcome).toBe('error');
+  });
+});


### PR DESCRIPTION
## Summary
- New `FetchOutcome` type on `CalendarInfoFetcher` (`'idle' | 'found' | 'not-found' | 'error'`), set by `runFetch` based on what actually happened
- Exposed via a `lastOutcome` getter; reset to `'idle'` by `reset()` and (via reset) by `forceRefetch()`
- `SettingTab` Refresh handler now clears `this.calendarUrl` + `this.calendarUpdatedAt` on any failure and picks a distinct Notice:
  - `not-found` → "No calendar found yet. Enable Save calendar to the web and trigger a save to create one."
  - `error` → "Couldn't refresh calendar info. Check your secret key and network connection."

## Why
Previously a failed Refresh showed a generic Notice next to a stale URL — confusing for the user. And the same Notice text fired whether the server said "no calendar exists" or whether we couldn't reach it, even though the right next action differs.

## Test plan
- [x] 7 new unit tests in `src/__tests__/CalendarInfoFetcher.test.ts` covering: initial `idle`, transitions to `found`/`not-found`/`error`, reset to `idle`, forceRefetch updating the outcome, and an error replacing a previous success
- [x] `bun run lint` — 0 errors
- [x] `bun run test` — Jest: 218/218 pass
- [x] `bun test` — bun native: 102/102 pass
- [x] `bun run build` — clean
- [ ] Manual: with an invalid secret key, click Refresh → confirm URL clears and 'check your secret key' Notice appears
- [ ] Manual: with a valid key but no saved calendar, click Refresh → confirm 'no calendar found yet' Notice with the save-to-web instruction

Fixes #193