### PR TITLE
Restore Refresh button after a failed Refresh (regression fix)

### DIFF
--- a/src/SettingTab.ts
+++ b/src/SettingTab.ts
@@ -274,9 +274,47 @@ export class SettingTab extends PluginSettingTab {
           }
         }));
 
-      // Calendar Status and URL
+      // Adds a 🔄 Refresh button to the given Setting. Extracted so the same
+      // button can appear on both the success row (alongside Copy) and the
+      // failure rows below — otherwise a Refresh failure would leave the user
+      // with no UI path to retry.
+      const addRefreshButton = (setting: Setting): Setting =>
+        setting.addButton((button: ButtonComponent) => {
+          button
+            .setButtonText('🔄 Refresh')
+            .setTooltip('Re-fetch calendar info from the server')
+            .onClick(async () => {
+              if (!settings.secretKey || settings.secretKey.length !== 32) return;
+              const client = apiClient(this.app.vault.getName(), settings.secretKey);
+              button.setButtonText('⏳ Refreshing…');
+              const info = await this.calendarFetcher.forceRefetch(client);
+              if (info) {
+                this.calendarUrl = info.url;
+                this.calendarUpdatedAt = info.updatedAt;
+              } else {
+                // Refresh failed. Clear the on-screen URL so the user isn't
+                // shown a stale link alongside a Notice that says they
+                // couldn't refresh it.
+                this.calendarUrl = null;
+                this.calendarUpdatedAt = null;
+                if (this.calendarFetcher.lastOutcome === 'not-found') {
+                  new Notice('No calendar found yet. Enable "Save calendar to the web" and trigger a save to create one.');
+                } else {
+                  new Notice('Couldn\'t refresh calendar info. Check your secret key and network connection.');
+                }
+              }
+              this.display();
+            });
+        });
+
+      // Calendar status. Branches on (calendarUrl, lastOutcome):
+      // - URL present: show URL + Copy + Refresh
+      // - no URL, not-found:  show explanatory row + Refresh
+      // - no URL, error:      show explanatory row + Refresh
+      // - no URL, idle:       show the original placeholder (no Refresh yet
+      //                       because we haven't attempted a fetch)
       if (this.calendarUrl) {
-        new Setting(containerEl)
+        const urlSetting = new Setting(containerEl)
           .setName('Calendar URL')
           .setDesc(createFragment((fragment) => {
             fragment.createEl('a', {
@@ -303,35 +341,16 @@ export class SettingTab extends PluginSettingTab {
                   button.setButtonText('📋 Copy to clipboard');
                 }, 500);
               });
-          })
-          .addButton((button: ButtonComponent) => {
-            button
-              .setButtonText('🔄 Refresh')
-              .setTooltip('Re-fetch calendar info from the server')
-              .onClick(async () => {
-                if (!settings.secretKey || settings.secretKey.length !== 32) return;
-                const client = apiClient(this.app.vault.getName(), settings.secretKey);
-                button.setButtonText('⏳ Refreshing…');
-                const info = await this.calendarFetcher.forceRefetch(client);
-                if (info) {
-                  this.calendarUrl = info.url;
-                  this.calendarUpdatedAt = info.updatedAt;
-                } else {
-                  // Refresh failed. Clear the on-screen URL so the user isn't
-                  // shown a stale link alongside a Notice that says they
-                  // couldn't refresh it — that combination is more confusing
-                  // than useful. The Refresh button stays available for retry.
-                  this.calendarUrl = null;
-                  this.calendarUpdatedAt = null;
-                  if (this.calendarFetcher.lastOutcome === 'not-found') {
-                    new Notice('No calendar found yet. Enable "Save calendar to the web" and trigger a save to create one.');
-                  } else {
-                    new Notice('Couldn\'t refresh calendar info. Check your secret key and network connection.');
-                  }
-                }
-                this.display();
-              });
           });
+        addRefreshButton(urlSetting);
+      } else if (this.calendarFetcher.lastOutcome === 'not-found') {
+        addRefreshButton(new Setting(containerEl)
+          .setName('No calendar saved yet')
+          .setDesc('Enable "Save calendar to the web" below and trigger a save, then click Refresh.'));
+      } else if (this.calendarFetcher.lastOutcome === 'error') {
+        addRefreshButton(new Setting(containerEl)
+          .setName('Couldn\'t fetch calendar info')
+          .setDesc('Check your secret key and network connection, then click Refresh.'));
       } else {
         containerEl.createEl('p', {
           cls: 'setting-item-description',


### PR DESCRIPTION
## Summary
- Restructure the Member Status calendar block to branch on `(calendarUrl, lastOutcome)`:
  - URL present → URL + Copy + Refresh (unchanged)
  - no URL, `not-found` → "No calendar saved yet" row + Refresh
  - no URL, `error` → "Couldn't fetch calendar info" row + Refresh
  - no URL, `idle` → original placeholder (no Refresh yet — no attempt has happened)
- Extract `addRefreshButton(setting)` so the three retry-capable branches share one implementation

## Why
After PR #195 cleared `this.calendarUrl` on a failed Refresh, the rendering fell through to the placeholder which had no Refresh button, and the fetcher's `hasAttempted` was true so no auto-retry happened either. The user was stuck until plugin reload or secret-key change. This restores a UI retry path while keeping the cleared-URL semantics.

## Test plan
- [x] `bun run lint` — 0 errors
- [x] `bun run test` — Jest: 218/218 pass
- [x] `bun test` — bun native: 102/102 pass
- [x] `bun run build` — clean
- [ ] Manual: revoke key → click Refresh → confirm "Couldn't fetch calendar info" row appears with a working Refresh button
- [ ] Manual: with a valid key but no saved calendar → click Refresh → confirm "No calendar saved yet" row + Refresh button

Fixes #196