### PR TITLE
Skip second Refresh click while one is already in flight

### DIFF
--- a/src/CalendarInfoFetcher.ts
+++ b/src/CalendarInfoFetcher.ts
@@ -40,6 +40,10 @@ export class CalendarInfoFetcher {
     return this.outcome;
   }
 
+  get isCurrentlyFetching(): boolean {
+    return this.isFetching;
+  }
+
   async fetchOnce(client: ApiClient): Promise<CalendarInfo | null> {
     if (this.hasAttemptedFetch || this.isFetching) {
       return this.cached;

--- a/src/SettingTab.ts
+++ b/src/SettingTab.ts
@@ -285,6 +285,11 @@ export class SettingTab extends PluginSettingTab {
             .setTooltip('Re-fetch calendar info from the server')
             .onClick(async () => {
               if (!settings.secretKey || settings.secretKey.length !== 32) return;
+              // A previous Refresh click is still in flight. Bail without
+              // doing anything — the in-flight call will paint its own
+              // result. Otherwise this handler reads lastOutcome === 'idle'
+              // and shows a misleading error Notice.
+              if (this.calendarFetcher.isCurrentlyFetching) return;
               const client = apiClient(this.app.vault.getName(), settings.secretKey);
               button.setButtonText('⏳ Refreshing…');
               const info = await this.calendarFetcher.forceRefetch(client);

--- a/src/__tests__/CalendarInfoFetcher.test.ts
+++ b/src/__tests__/CalendarInfoFetcher.test.ts
@@ -191,6 +191,58 @@ describe('CalendarInfoFetcher.lastOutcome', () => {
     expect(fetcher.info).toBeNull();
   });
 
+  it('isCurrentlyFetching is false initially, true while fetching, false after resolution', async () => {
+    let resolve!: (v: FoundCalendar) => void;
+    const pending = new Promise<FoundCalendar>((res) => {
+      resolve = res;
+    });
+    const getCalendar = jest.fn().mockReturnValue(pending);
+    const client = { getCalendar } as unknown as ApiClient;
+    const fetcher = new CalendarInfoFetcher();
+
+    expect(fetcher.isCurrentlyFetching).toBe(false);
+    const pendingFetch = fetcher.fetchOnce(client);
+    expect(fetcher.isCurrentlyFetching).toBe(true);
+
+    resolve({ found: true, url: 'https://x.com/cal', updatedAt: '2026-05-27T10:00:00Z' });
+    await pendingFetch;
+    expect(fetcher.isCurrentlyFetching).toBe(false);
+  });
+
+  it('isCurrentlyFetching is false after a not-found resolution', async () => {
+    let resolve!: (v: NotFoundCalendar) => void;
+    const pending = new Promise<NotFoundCalendar>((res) => {
+      resolve = res;
+    });
+    const getCalendar = jest.fn().mockReturnValue(pending);
+    const client = { getCalendar } as unknown as ApiClient;
+    const fetcher = new CalendarInfoFetcher();
+
+    const pendingFetch = fetcher.fetchOnce(client);
+    expect(fetcher.isCurrentlyFetching).toBe(true);
+
+    resolve({ found: false, url: null, updatedAt: null });
+    await pendingFetch;
+    expect(fetcher.isCurrentlyFetching).toBe(false);
+  });
+
+  it('isCurrentlyFetching is false after an error resolution', async () => {
+    let reject!: (e: Error) => void;
+    const pending = new Promise<FoundCalendar>((_, rej) => {
+      reject = rej;
+    });
+    const getCalendar = jest.fn().mockReturnValue(pending);
+    const client = { getCalendar } as unknown as ApiClient;
+    const fetcher = new CalendarInfoFetcher();
+
+    const pendingFetch = fetcher.fetchOnce(client);
+    expect(fetcher.isCurrentlyFetching).toBe(true);
+
+    reject(new Error('network down'));
+    await pendingFetch;
+    expect(fetcher.isCurrentlyFetching).toBe(false);
+  });
+
   it('an error after a previous success replaces the outcome', async () => {
     const { client } = makeClient([
       { found: true, url: 'https://x.com/cal', updatedAt: '2026-05-27T10:00:00Z' },


### PR DESCRIPTION
## Summary
- Add `CalendarInfoFetcher.isCurrentlyFetching` getter
- SettingTab Refresh handler bails out early when it's true so the in-flight call can paint its own result
- 3 new unit tests covering the getter lifecycle for success / not-found / error resolutions

## Why
Double-clicking the Refresh button during an in-flight fetch hit a bug: the second click saw `lastOutcome === 'idle'` (the first click had reset it but not completed) and fell into the generic error Notice branch. If the first click then succeeded the user saw the new URL alongside a misleading "couldn't refresh" Notice.

## Test plan
- [x] `bun run lint` — 0 errors
- [x] `bun run test` — Jest: 221/221 pass (3 new tests)
- [x] `bun test` — bun native: 102/102 pass
- [x] `bun run build` — clean

Fixes #197