### PR TITLE
Drop stale fetch results when reset races with in-flight fetch

### DIFF
--- a/src/CalendarInfoFetcher.ts
+++ b/src/CalendarInfoFetcher.ts
@@ -21,11 +21,18 @@ export class CalendarInfoFetcher {
   private isFetching: boolean = false;
   private cached: CalendarInfo | null = null;
   private outcome: FetchOutcome = 'idle';
+  // Incremented by reset(). runFetch captures it at the start and discards
+  // its result on completion if the value has changed — i.e. if a
+  // reset()/secretKey change invalidated the request mid-flight. Without
+  // this guard the in-flight fetch's finally block would overwrite freshly
+  // reset state with the stale-key result.
+  private currentToken: number = 0;
 
   reset(): void {
     this.hasAttemptedFetch = false;
     this.cached = null;
     this.outcome = 'idle';
+    this.currentToken++;
   }
 
   get info(): CalendarInfo | null {
@@ -60,25 +67,33 @@ export class CalendarInfoFetcher {
   }
 
   private async runFetch(client: ApiClient): Promise<CalendarInfo | null> {
+    const myToken = this.currentToken;
     this.isFetching = true;
+    let nextCached: CalendarInfo | null = null;
+    let nextOutcome: FetchOutcome;
     try {
       const response = await client.getCalendar();
       if (response.found && response.url && response.updatedAt) {
-        this.cached = { url: response.url, updatedAt: response.updatedAt };
-        this.outcome = 'found';
+        nextCached = { url: response.url, updatedAt: response.updatedAt };
+        nextOutcome = 'found';
       } else {
-        this.cached = null;
-        this.outcome = 'not-found';
+        nextOutcome = 'not-found';
       }
     } catch {
       // The validation status is owned by the separate ApiClient.isActive
       // cache; failures here only affect the calendar URL display.
-      this.cached = null;
-      this.outcome = 'error';
-    } finally {
-      this.isFetching = false;
-      this.hasAttemptedFetch = true;
+      nextOutcome = 'error';
     }
+    this.isFetching = false;
+    // If the token changed (reset() / secretKey change), our result is
+    // stale and shouldn't clobber the post-reset state. Return null so
+    // callers can detect the silent-drop case too.
+    if (myToken !== this.currentToken) {
+      return null;
+    }
+    this.cached = nextCached;
+    this.outcome = nextOutcome;
+    this.hasAttemptedFetch = true;
     return this.cached;
   }
 }

--- a/src/SettingTab.ts
+++ b/src/SettingTab.ts
@@ -284,15 +284,21 @@ export class SettingTab extends PluginSettingTab {
             .setButtonText('🔄 Refresh')
             .setTooltip('Re-fetch calendar info from the server')
             .onClick(async () => {
-              if (!settings.secretKey || settings.secretKey.length !== 32) return;
+              const keyAtStart = settings.secretKey;
+              if (!keyAtStart || keyAtStart.length !== 32) return;
               // A previous Refresh click is still in flight. Bail without
               // doing anything — the in-flight call will paint its own
               // result. Otherwise this handler reads lastOutcome === 'idle'
               // and shows a misleading error Notice.
               if (this.calendarFetcher.isCurrentlyFetching) return;
-              const client = apiClient(this.app.vault.getName(), settings.secretKey);
+              const client = apiClient(this.app.vault.getName(), keyAtStart);
               button.setButtonText('⏳ Refreshing…');
               const info = await this.calendarFetcher.forceRefetch(client);
+              // The user changed their secret key while the refresh was in
+              // flight. The fetcher already dropped its result; we also
+              // suppress the failure UI so the user isn't shown a Notice
+              // that refers to a key they no longer have set.
+              if (settings.secretKey !== keyAtStart) return;
               if (info) {
                 this.calendarUrl = info.url;
                 this.calendarUpdatedAt = info.updatedAt;

--- a/src/__tests__/CalendarInfoFetcher.test.ts
+++ b/src/__tests__/CalendarInfoFetcher.test.ts
@@ -257,3 +257,98 @@ describe('CalendarInfoFetcher.lastOutcome', () => {
     expect(fetcher.lastOutcome).toBe('error');
   });
 });
+
+describe('CalendarInfoFetcher stale-completion guard', () => {
+  it('drops the result when reset() is called during in-flight fetch', async () => {
+    let resolve!: (v: FoundCalendar) => void;
+    const pending = new Promise<FoundCalendar>((res) => {
+      resolve = res;
+    });
+    const getCalendar = jest.fn().mockReturnValue(pending);
+    const client = { getCalendar } as unknown as ApiClient;
+    const fetcher = new CalendarInfoFetcher();
+
+    const pendingFetch = fetcher.fetchOnce(client);
+    expect(fetcher.isCurrentlyFetching).toBe(true);
+
+    // The user changed their secret key mid-fetch — SettingTab's
+    // clearMemberStatus() would call this.
+    fetcher.reset();
+    expect(fetcher.lastOutcome).toBe('idle');
+    expect(fetcher.hasAttempted).toBe(false);
+
+    resolve({ found: true, url: 'https://x.com/old-key-cal', updatedAt: '2026-05-27T10:00:00Z' });
+    const result = await pendingFetch;
+
+    // The stale completion must not have applied — the fetcher should
+    // still be in its post-reset state, not holding the old-key data.
+    expect(result).toBeNull();
+    expect(fetcher.info).toBeNull();
+    expect(fetcher.lastOutcome).toBe('idle');
+    expect(fetcher.hasAttempted).toBe(false);
+    expect(fetcher.isCurrentlyFetching).toBe(false);
+  });
+
+  it('drops an in-flight error result that resolves after reset()', async () => {
+    let reject!: (e: Error) => void;
+    const pending = new Promise<FoundCalendar>((_, rej) => {
+      reject = rej;
+    });
+    const getCalendar = jest.fn().mockReturnValue(pending);
+    const client = { getCalendar } as unknown as ApiClient;
+    const fetcher = new CalendarInfoFetcher();
+
+    const pendingFetch = fetcher.fetchOnce(client);
+    fetcher.reset();
+
+    reject(new Error('network down after reset'));
+    await pendingFetch;
+
+    // Outcome must NOT be 'error' — the reset invalidated the fetch and
+    // the late rejection is irrelevant.
+    expect(fetcher.lastOutcome).toBe('idle');
+    expect(fetcher.hasAttempted).toBe(false);
+  });
+
+  it('still applies the result when no reset() happens during the fetch', async () => {
+    // Sanity check that the guard doesn't break the normal path.
+    const { client } = makeClient([
+      { found: true, url: 'https://x.com/cal', updatedAt: '2026-05-27T10:00:00Z' },
+    ]);
+    const fetcher = new CalendarInfoFetcher();
+
+    const info = await fetcher.fetchOnce(client);
+
+    expect(info).toEqual({ url: 'https://x.com/cal', updatedAt: '2026-05-27T10:00:00Z' });
+    expect(fetcher.info).toEqual(info);
+    expect(fetcher.lastOutcome).toBe('found');
+    expect(fetcher.hasAttempted).toBe(true);
+  });
+
+  it('a subsequent fresh fetch after a stale drop still applies normally', async () => {
+    // Click 1 fetch is dropped because of a reset, then a normal fetchOnce
+    // should still work for the new context.
+    let resolveFirst!: (v: FoundCalendar) => void;
+    const firstPending = new Promise<FoundCalendar>((res) => {
+      resolveFirst = res;
+    });
+    const getCalendar = jest.fn()
+      .mockReturnValueOnce(firstPending)
+      .mockResolvedValueOnce({ found: true, url: 'https://x.com/new', updatedAt: '2026-05-27T12:00:00Z' });
+    const client = { getCalendar } as unknown as ApiClient;
+    const fetcher = new CalendarInfoFetcher();
+
+    const firstFetch = fetcher.fetchOnce(client);
+    fetcher.reset();
+    resolveFirst({ found: true, url: 'https://x.com/old', updatedAt: '2026-05-27T10:00:00Z' });
+    await firstFetch;
+
+    // Now fetch fresh — should land normally.
+    const secondInfo = await fetcher.fetchOnce(client);
+
+    expect(secondInfo).toEqual({ url: 'https://x.com/new', updatedAt: '2026-05-27T12:00:00Z' });
+    expect(fetcher.info?.url).toBe('https://x.com/new');
+    expect(fetcher.lastOutcome).toBe('found');
+    expect(fetcher.hasAttempted).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- New `currentToken` counter on `CalendarInfoFetcher`, bumped by `reset()`
- `runFetch` captures the token at start, drops its result on completion if the value has changed (an intervening `reset()` invalidated this attempt)
- `isFetching` is set to false unconditionally so the fetcher isn't permanently locked after a stale completion
- SettingTab Refresh handler also captures `settings.secretKey` at the start and bails on the post-await side-effects if the key has changed in the meantime — suppresses the now-irrelevant Notice that would otherwise reference an abandoned attempt

## Why
If a user clicked Refresh and then changed their secret key (or any other code path called `reset()`) before the in-flight fetch resolved, the fetch's finally block wrote its old-key result into the fetcher unconditionally — corrupting state and causing a misleading "couldn't refresh" Notice referencing the abandoned attempt.

## Test plan
- [x] 4 new unit tests in `src/__tests__/CalendarInfoFetcher.test.ts`:
  - Mid-flight `reset()` → late success drops result, state stays post-reset
  - Mid-flight `reset()` → late rejection drops error outcome
  - Sanity: no `reset()` → result still applies normally
  - A fresh fetch after a stale drop still applies normally
- [x] `bun run lint` — 0 errors
- [x] `bun run test` — Jest: 225/225 pass
- [x] `bun test` — bun native: 102/102 pass
- [x] `bun run build` — clean

Fixes #198