### PR TITLE
Release isFetching on reset() so fetchOnce can start after a race

### DIFF
--- a/src/CalendarInfoFetcher.ts
+++ b/src/CalendarInfoFetcher.ts
@@ -33,6 +33,12 @@ export class CalendarInfoFetcher {
     this.cached = null;
     this.outcome = 'idle';
     this.currentToken++;
+    // Abandon the tracking for any in-flight fetch. The actual network call
+    // keeps running but its result will be dropped via the token check —
+    // letting it block isFetching would gate the next fetchOnce until the
+    // old call resolves, which can strand the UI on the empty-state
+    // placeholder after a key-change race.
+    this.isFetching = false;
   }
 
   get info(): CalendarInfo | null {
@@ -84,13 +90,13 @@ export class CalendarInfoFetcher {
       // cache; failures here only affect the calendar URL display.
       nextOutcome = 'error';
     }
-    this.isFetching = false;
-    // If the token changed (reset() / secretKey change), our result is
-    // stale and shouldn't clobber the post-reset state. Return null so
-    // callers can detect the silent-drop case too.
+    // Stale completion: a reset() (and possibly a new runFetch) happened
+    // while we were awaiting. Don't apply state — and don't touch
+    // isFetching, since a newer fetch may now own it.
     if (myToken !== this.currentToken) {
       return null;
     }
+    this.isFetching = false;
     this.cached = nextCached;
     this.outcome = nextOutcome;
     this.hasAttemptedFetch = true;

--- a/src/__tests__/CalendarInfoFetcher.test.ts
+++ b/src/__tests__/CalendarInfoFetcher.test.ts
@@ -325,6 +325,52 @@ describe('CalendarInfoFetcher stale-completion guard', () => {
     expect(fetcher.hasAttempted).toBe(true);
   });
 
+  it('reset() releases isFetching so a new fetchOnce can start without waiting for the old fetch', async () => {
+    let resolveOld!: (v: FoundCalendar) => void;
+    const oldPending = new Promise<FoundCalendar>((res) => {
+      resolveOld = res;
+    });
+    let resolveNew!: (v: FoundCalendar) => void;
+    const newPending = new Promise<FoundCalendar>((res) => {
+      resolveNew = res;
+    });
+    const getCalendar = jest.fn()
+      .mockReturnValueOnce(oldPending)
+      .mockReturnValueOnce(newPending);
+    const client = { getCalendar } as unknown as ApiClient;
+    const fetcher = new CalendarInfoFetcher();
+
+    const oldFetch = fetcher.fetchOnce(client);
+    expect(fetcher.isCurrentlyFetching).toBe(true);
+
+    // Simulate a secret-key change — clearMemberStatus calls reset().
+    // The gate should release so a new fetchOnce can start.
+    fetcher.reset();
+    expect(fetcher.isCurrentlyFetching).toBe(false);
+
+    const newFetch = fetcher.fetchOnce(client);
+    expect(fetcher.isCurrentlyFetching).toBe(true);
+    expect(getCalendar).toHaveBeenCalledTimes(2);
+
+    // New fetch resolves first with the new key's data.
+    resolveNew({ found: true, url: 'https://x.com/new', updatedAt: '2026-05-27T12:00:00Z' });
+    const newResult = await newFetch;
+    expect(newResult?.url).toBe('https://x.com/new');
+    expect(fetcher.info?.url).toBe('https://x.com/new');
+    expect(fetcher.lastOutcome).toBe('found');
+    expect(fetcher.isCurrentlyFetching).toBe(false);
+
+    // Old fetch resolves late with the abandoned key's data. The token
+    // check must drop it without corrupting the new state and without
+    // touching isFetching (which is now false from the new fetch's
+    // completion).
+    resolveOld({ found: true, url: 'https://x.com/old', updatedAt: '2026-05-27T10:00:00Z' });
+    const oldResult = await oldFetch;
+    expect(oldResult).toBeNull();
+    expect(fetcher.info?.url).toBe('https://x.com/new');
+    expect(fetcher.isCurrentlyFetching).toBe(false);
+  });
+
   it('a subsequent fresh fetch after a stale drop still applies normally', async () => {
     // Click 1 fetch is dropped because of a reset, then a normal fetchOnce
     // should still work for the new context.


### PR DESCRIPTION
## Summary
- `reset()` sets `isFetching = false` alongside bumping the token — the in-flight network call keeps running but we no longer track it
- `runFetch`'s finally block only sets `isFetching = false` when the token matches, so a stale completion can't clobber a fresh fetch's `isFetching = true`
- New unit test exercises: in-flight → reset() → immediate new fetchOnce → both fetches resolve in any order without state corruption

## Why
Edge-case race: if a user changed their secret key while a Refresh was in flight AND `isActive(newKey)` resolved before the old `getCalendar`, the new key's `fetchOnce` was gated on `isFetching` until the old fetch eventually resolved. By then nothing was triggering another `fetchOnce`, leaving the UI on the empty placeholder until the user toggled an unrelated setting.

## Test plan
- [x] `bun run lint` — 0 errors
- [x] `bun run test` — Jest: 226/226 pass (1 new test)
- [x] `bun test` — bun native: 102/102 pass
- [x] `bun run build` — clean

Fixes #202