### PR TITLE
Don't log raw SettingsManager — getters leak secrets via DevTools

### DIFF
--- a/src/Main.ts
+++ b/src/Main.ts
@@ -62,7 +62,11 @@ export class Main {
     log('Performing a scan');
     log('Settings', { settings: settings.settingsWithoutSecrets() });
 
-    log(`Found ${markdownFiles.length} Markdown files in ${settings.rootPath}`, { markdownFiles, settings });
+    // Intentionally omit `settings` from the second arg. The SettingsManager
+    // has getters for secretKey / githubPersonalAccessToken that resolve
+    // against localStorage when inspected in DevTools — passing it raw here
+    // would defeat the redaction that line above already prints.
+    log(`Found ${markdownFiles.length} Markdown files in ${settings.rootPath}`, { markdownFiles });
 
     // Iterate over all of the Markdown files in this vault
     for (const file of markdownFiles) {


### PR DESCRIPTION
## Summary
- `src/Main.ts:65` no longer passes the raw `settings` (SettingsManager) instance to the debug log
- Inline comment documents why, so a future contributor doesn't re-add it
- `settings.settingsWithoutSecrets()` on the line above is unchanged — the redacted view continues to be logged

## Why
The `SettingsManager` has getters for `secretKey` and `githubPersonalAccessToken` that read straight from localStorage (per the SecretStore migration). When a user with `isDebug: true` opens DevTools and expands the logged object, the inspector evaluates those getters and shows the secrets — defeating the redaction.

## Test plan
- [x] `bun run lint` — 0 errors
- [x] `bun run test` — Jest: 226/226 pass (unchanged)
- [x] `bun test` — bun native: 102/102 pass
- [x] `bun run build` — clean
- [ ] Manual: with `isDebug: true`, save a calendar, open DevTools console, expand the `Found N Markdown files…` log entry → confirm there's no `secretKey` / `githubPersonalAccessToken` field visible

Fixes #204