### PR TITLE
Escape DESCRIPTION and LOCATION as RFC 5545 TEXT

### DIFF
--- a/src/IcalService.ts
+++ b/src/IcalService.ts
@@ -2,6 +2,7 @@ import { Task } from './Model/Task';
 import { TaskDateName } from './Model/TaskDate';
 import { TaskStatus } from './Model/TaskStatus';
 import { settings } from './SettingsManager';
+import { escapeICalText } from './iCalText';
 
 export class IcalService {
   getCalendar(tasks: Task[]): string {
@@ -145,10 +146,15 @@ export class IcalService {
         'DTSTART:' + date + '\r\n';
     }
 
+    // ALTREP parameter values live inside DQUOTE — they're URIs, not TEXT, so
+    // they don't get the comma/semicolon backslash-escaping. The LOCATION
+    // value section (after the ':') IS TEXT and DOES need escaping.
+    const urlEncoded = encodeURI(task.getLocation());
+
     event += '' +
       'SUMMARY:' + prependSummary + task.getSummary() + '\r\n' +
-      (settings.isIncludeLinkInDescription ? 'DESCRIPTION:' + encodeURI(task.getLocation()) + '\r\n' : '') +
-      (settings.isIncludeLocation ? 'LOCATION:ALTREP="' + encodeURI(task.getLocation()) + '":' + encodeURI(task.getLocation()) + '\r\n' : '') +
+      (settings.isIncludeLinkInDescription ? 'DESCRIPTION:' + escapeICalText(urlEncoded) + '\r\n' : '') +
+      (settings.isIncludeLocation ? 'LOCATION:ALTREP="' + urlEncoded + '":' + escapeICalText(urlEncoded) + '\r\n' : '') +
       'END:VEVENT\r\n';
 
     return event;
@@ -168,13 +174,17 @@ export class IcalService {
   }
 
   private getToDo(task: Task): string {
+    // ALTREP value lives inside DQUOTE (URI-rules, no TEXT escaping).
+    // LOCATION value section after ':' is TEXT and DOES need escaping.
+    const urlEncoded = encodeURI(task.getLocation());
+
     let toDo = '' +
       'BEGIN:VTODO\r\n' +
       'UID:' + task.getId() + '\r\n' +
       'SUMMARY:' + task.getSummary() + '\r\n' +
       // If a task does not have a date, do not include the DTSTAMP property
       (task.hasAnyDate() ? 'DTSTAMP:' + task.getDate(null, 'YYYYMMDDTHHmmss') + '\r\n' : '') +
-      (settings.isIncludeLocation ? 'LOCATION:ALTREP="' + encodeURI(task.getLocation()) + '":' + encodeURI(task.getLocation()) + '\r\n' : '');
+      (settings.isIncludeLocation ? 'LOCATION:ALTREP="' + urlEncoded + '":' + escapeICalText(urlEncoded) + '\r\n' : '');
 
     if (task.hasA(TaskDateName.Due)) {
       toDo += 'DUE;VALUE=DATE:' + task.getDate(TaskDateName.Due, 'YYYYMMDD') + '\r\n';
@@ -201,7 +211,7 @@ export class IcalService {
 
 
     if (settings.isIncludeLinkInDescription) {
-      toDo += 'DESCRIPTION:' + encodeURI(task.getLocation()) + '\r\n';
+      toDo += 'DESCRIPTION:' + escapeICalText(urlEncoded) + '\r\n';
     }
 
     toDo += 'END:VTODO\r\n';

--- a/src/Model/Task.ts
+++ b/src/Model/Task.ts
@@ -3,6 +3,7 @@ import { TaskDate, TaskDateName, getTaskDatesFromMarkdown, hasTime } from './Tas
 import { TaskStatus, getTaskStatusEmoji, getTaskStatusFromMarkdown } from './TaskStatus';
 import { getSummaryFromMarkdown } from './TaskSummary';
 import { settings } from '../SettingsManager';
+import { escapeICalText } from '../iCalText';
 
 export class Task {
   public status: TaskStatus;
@@ -78,14 +79,8 @@ export class Task {
   }
 
   public getSummary(): string {
-    const summary = this.summary
-      .replace(/\\/gm, '\\\\')
-      .replace(/\r?\n/gm, '\\n')
-      .replace(/;/gm, '\\;')
-      .replace(/,/gm, '\\,');
-
+    const summary = escapeICalText(this.summary);
     const emoji = getTaskStatusEmoji(this.status);
-
     return `${emoji} ${summary}`;
   }
 

--- a/src/__tests__/IcalService.test.ts
+++ b/src/__tests__/IcalService.test.ts
@@ -159,3 +159,57 @@ describe('IcalService UID stability across exports', () => {
     expect(extractUids(original)).not.toEqual(extractUids(edited));
   });
 });
+
+describe('IcalService DESCRIPTION/LOCATION iCal-escaping', () => {
+  beforeEach(() => {
+    mockSettings.isIncludeLocation = true;
+    mockSettings.isIncludeLinkInDescription = true;
+    mockSettings.includeEventsOrTodos = 'EventsOnly';
+    mockSettings.howToProcessMultipleDates = 'PreferDueDate';
+  });
+
+  function buildTaskWithLocation(fileUri: string): Task {
+    return new Task(
+      TaskStatus.ToDo,
+      [{ name: TaskDateName.Due, date: new Date(2026, 4, 15), isDateOnly: true } as any],
+      'Sample task',
+      fileUri,
+    );
+  }
+
+  it('escapes commas in the DESCRIPTION value when the file path contains them', () => {
+    const ical = new IcalService().getCalendar([
+      buildTaskWithLocation('obsidian://open?vault=v&file=Meeting, 2024.md'),
+    ]);
+    // Comma in the URL must be backslash-escaped per RFC 5545 §3.3.11.
+    expect(ical).toMatch(/DESCRIPTION:[^\r\n]*Meeting\\,/);
+    expect(ical).not.toMatch(/DESCRIPTION:[^\r\n]*Meeting,/);
+  });
+
+  it('escapes semicolons in the DESCRIPTION value', () => {
+    const ical = new IcalService().getCalendar([
+      buildTaskWithLocation('obsidian://open?vault=v&file=a;b.md'),
+    ]);
+    expect(ical).toMatch(/DESCRIPTION:[^\r\n]*a\\;b/);
+  });
+
+  it('escapes commas in the LOCATION TEXT value but NOT inside the ALTREP DQUOTE parameter', () => {
+    const ical = new IcalService().getCalendar([
+      buildTaskWithLocation('obsidian://open?vault=v&file=Meeting, 2024.md'),
+    ]);
+    // The ALTREP parameter (inside DQUOTE) keeps the raw comma — it's a URI,
+    // not iCal TEXT. encodeURI URL-encodes the space to %20 but leaves , alone.
+    expect(ical).toMatch(/LOCATION:ALTREP="[^"]*Meeting,%202024\.md"/);
+    // The LOCATION value (after the closing quote and colon) IS TEXT and the
+    // comma must be escaped.
+    expect(ical).toMatch(/LOCATION:ALTREP="[^"]*":[^\r\n]*Meeting\\,%202024\.md/);
+  });
+
+  it('passes plain URLs through unchanged (regression for the common case)', () => {
+    const ical = new IcalService().getCalendar([
+      buildTaskWithLocation('obsidian://open?vault=v&file=note.md'),
+    ]);
+    expect(ical).toContain('DESCRIPTION:obsidian://open?vault=v&file=note.md');
+    expect(ical).toContain('LOCATION:ALTREP="obsidian://open?vault=v&file=note.md":obsidian://open?vault=v&file=note.md');
+  });
+});

--- a/src/__tests__/iCalText.test.ts
+++ b/src/__tests__/iCalText.test.ts
@@ -1,0 +1,45 @@
+import { escapeICalText } from '../iCalText';
+
+describe('escapeICalText', () => {
+  it('escapes a literal backslash', () => {
+    expect(escapeICalText('a\\b')).toBe('a\\\\b');
+  });
+
+  it('escapes a semicolon', () => {
+    expect(escapeICalText('one;two')).toBe('one\\;two');
+  });
+
+  it('escapes a comma', () => {
+    expect(escapeICalText('one,two,three')).toBe('one\\,two\\,three');
+  });
+
+  it('converts \\n line breaks', () => {
+    expect(escapeICalText('one\ntwo')).toBe('one\\ntwo');
+  });
+
+  it('converts \\r\\n line breaks', () => {
+    expect(escapeICalText('one\r\ntwo')).toBe('one\\ntwo');
+  });
+
+  it('escapes backslash before applying the other replacements (order matters)', () => {
+    // A literal "\," in the input must end up as "\\\\\\," — backslash first,
+    // then the comma. If order were wrong we'd get "\\\\,".
+    expect(escapeICalText('a\\,b')).toBe('a\\\\\\,b');
+  });
+
+  it('passes plain text through untouched', () => {
+    expect(escapeICalText('Hello world')).toBe('Hello world');
+  });
+
+  it('passes Unicode and emoji through untouched', () => {
+    expect(escapeICalText('Buy 🥛 milk')).toBe('Buy 🥛 milk');
+  });
+
+  it('handles the empty string', () => {
+    expect(escapeICalText('')).toBe('');
+  });
+
+  it('escapes all four special characters in one string', () => {
+    expect(escapeICalText('a\\b;c,d\ne')).toBe('a\\\\b\\;c\\,d\\ne');
+  });
+});

--- a/src/iCalText.ts
+++ b/src/iCalText.ts
@@ -1,0 +1,14 @@
+// RFC 5545 §3.3.11 TEXT escape rules. Apply to property values whose type is
+// TEXT — e.g. SUMMARY, DESCRIPTION, LOCATION. Property *parameter* values that
+// live inside DQUOTE (e.g. ALTREP="...") follow different rules and should
+// NOT be passed through here.
+//
+// Order matters: escape backslashes first so subsequent escape sequences
+// don't get double-escaped.
+export function escapeICalText(value: string): string {
+  return value
+    .replace(/\\/g, '\\\\')
+    .replace(/\r?\n/g, '\\n')
+    .replace(/;/g, '\\;')
+    .replace(/,/g, '\\,');
+}


### PR DESCRIPTION
## Summary
- New `src/iCalText.ts` exposing `escapeICalText()` — applies RFC 5545 §3.3.11 TEXT escapes (`\\`, `\\n`, `\;`, `\\,`)
- `Task.getSummary()` refactored to delegate to it (was doing the same thing inline)
- `IcalService` applies `escapeICalText` after `encodeURI` on the DESCRIPTION and the LOCATION value sections
- ALTREP parameter values inside DQUOTE stay raw — they're URIs, not TEXT, and use different escape rules

## Why
`encodeURI` doesn't touch `,` or `;`, so files with commas in vault names or note paths (e.g. `Meeting, 2024-05-01.md`) produced malformed iCal — strict parsers would split DESCRIPTION at the unescaped comma. SUMMARY was already safe via Task.getSummary; DESCRIPTION and LOCATION just weren't doing the same step.

## Test plan
- [x] 10 new tests in `iCalText.test.ts` (backslash-first order, all four specials, Unicode, empty string)
- [x] 4 new tests in `IcalService.test.ts` (comma in DESCRIPTION, semicolon in DESCRIPTION, asymmetric LOCATION ALTREP/value, plain-URL regression)
- [x] `bun run lint` — 0 errors
- [x] `bun run test` — Jest: 245/245 pass
- [x] `bun test` — bun native: 102/102 pass
- [x] `bun run build` — clean

Fixes #208