### PR TITLE
Use ; (not :) to separate LOCATION property parameter from name

### DIFF
--- a/src/IcalService.ts
+++ b/src/IcalService.ts
@@ -154,7 +154,7 @@ export class IcalService {
     event += '' +
       'SUMMARY:' + prependSummary + task.getSummary() + '\r\n' +
       (settings.isIncludeLinkInDescription ? 'DESCRIPTION:' + escapeICalText(urlEncoded) + '\r\n' : '') +
-      (settings.isIncludeLocation ? 'LOCATION:ALTREP="' + urlEncoded + '":' + escapeICalText(urlEncoded) + '\r\n' : '') +
+      (settings.isIncludeLocation ? 'LOCATION;ALTREP="' + urlEncoded + '":' + escapeICalText(urlEncoded) + '\r\n' : '') +
       'END:VEVENT\r\n';
 
     return event;
@@ -184,7 +184,7 @@ export class IcalService {
       'SUMMARY:' + task.getSummary() + '\r\n' +
       // If a task does not have a date, do not include the DTSTAMP property
       (task.hasAnyDate() ? 'DTSTAMP:' + task.getDate(null, 'YYYYMMDDTHHmmss') + '\r\n' : '') +
-      (settings.isIncludeLocation ? 'LOCATION:ALTREP="' + urlEncoded + '":' + escapeICalText(urlEncoded) + '\r\n' : '');
+      (settings.isIncludeLocation ? 'LOCATION;ALTREP="' + urlEncoded + '":' + escapeICalText(urlEncoded) + '\r\n' : '');
 
     if (task.hasA(TaskDateName.Due)) {
       toDo += 'DUE;VALUE=DATE:' + task.getDate(TaskDateName.Due, 'YYYYMMDD') + '\r\n';

--- a/src/__tests__/IcalService.test.ts
+++ b/src/__tests__/IcalService.test.ts
@@ -68,7 +68,7 @@ describe('IcalService location toggle', () => {
   it('includes LOCATION line in VEVENT when isIncludeLocation is true', () => {
     mockSettings.isIncludeLocation = true;
     const ical = new IcalService().getCalendar([buildTaskWithDueDate()]);
-    expect(ical).toContain('LOCATION:ALTREP=');
+    expect(ical).toContain('LOCATION;ALTREP=');
   });
 
   it('omits LOCATION line in VEVENT when isIncludeLocation is false', () => {
@@ -199,10 +199,10 @@ describe('IcalService DESCRIPTION/LOCATION iCal-escaping', () => {
     ]);
     // The ALTREP parameter (inside DQUOTE) keeps the raw comma — it's a URI,
     // not iCal TEXT. encodeURI URL-encodes the space to %20 but leaves , alone.
-    expect(ical).toMatch(/LOCATION:ALTREP="[^"]*Meeting,%202024\.md"/);
+    expect(ical).toMatch(/LOCATION;ALTREP="[^"]*Meeting,%202024\.md"/);
     // The LOCATION value (after the closing quote and colon) IS TEXT and the
     // comma must be escaped.
-    expect(ical).toMatch(/LOCATION:ALTREP="[^"]*":[^\r\n]*Meeting\\,%202024\.md/);
+    expect(ical).toMatch(/LOCATION;ALTREP="[^"]*":[^\r\n]*Meeting\\,%202024\.md/);
   });
 
   it('passes plain URLs through unchanged (regression for the common case)', () => {
@@ -210,6 +210,6 @@ describe('IcalService DESCRIPTION/LOCATION iCal-escaping', () => {
       buildTaskWithLocation('obsidian://open?vault=v&file=note.md'),
     ]);
     expect(ical).toContain('DESCRIPTION:obsidian://open?vault=v&file=note.md');
-    expect(ical).toContain('LOCATION:ALTREP="obsidian://open?vault=v&file=note.md":obsidian://open?vault=v&file=note.md');
+    expect(ical).toContain('LOCATION;ALTREP="obsidian://open?vault=v&file=note.md":obsidian://open?vault=v&file=note.md');
   });
 });


### PR DESCRIPTION
## Summary
- `LOCATION:ALTREP="...":value` → `LOCATION;ALTREP="...":value` in both VEVENT and VTODO output
- IcalService tests updated to match

## Why
Per RFC 5545 §3.1, property parameters are introduced with `;`, not `:`. The old output is malformed; lenient parsers treat the entire `ALTREP="...":value` string as the LOCATION value rather than parsing ALTREP as a parameter.

## Snapshot fixture
The committed legacy snapshot `test/obsidian-ical-plugin.ics` still contains the old format. The legacy bun test doesn't assert on LOCATION content beyond presence so it's unaffected by this change. The snapshot can be regenerated after release.

## Test plan
- [x] `bun run lint` — 0 errors
- [x] `bun run test` — Jest: 245/245 pass
- [x] `bun test` — bun native: 102/102 pass
- [x] `bun run build` — clean

Fixes #209