### PR TITLE
URL-encode vault name and file path in fileUri construction

### DIFF
--- a/src/TaskFinder.ts
+++ b/src/TaskFinder.ts
@@ -13,7 +13,13 @@ export class TaskFinder {
   async findTasks(file: TFile, listItemsCache: ListItemCache[], headings: Headings|undefined): Promise<Task[]> {
     const fileCachedContent: string = await this.vault.cachedRead(file);
     const lines: string[] = fileCachedContent.split('\n');
-    const fileUri: string = 'obsidian://open?vault=' + file.vault.getName() + '&file=' + file.path;
+    // Use encodeURIComponent for the variable parts so reserved URL chars in
+    // the vault name or file path (&, ?, #, +, =, space) get percent-encoded.
+    // Plain concatenation would produce malformed URLs that calendar apps
+    // can't open.
+    const fileUri: string =
+      'obsidian://open?vault=' + encodeURIComponent(file.vault.getName()) +
+      '&file=' + encodeURIComponent(file.path);
 
     const tasks: Task[] = listItemsCache
       // Get the position of each list item

--- a/src/__tests__/TaskFinder.test.ts
+++ b/src/__tests__/TaskFinder.test.ts
@@ -195,6 +195,86 @@ describe('TaskFinder.findTasks — Day Planner dateOverride scoping', () => {
     expect(due!.getDate()).toBe(1);
   });
 
+  describe('fileUri URL-encoding', () => {
+    function getFileUriFromTask(task: { fileUri: string }): string {
+      return task.fileUri;
+    }
+
+    it('percent-encodes & in the vault name', async () => {
+      const { vault, listItemsCache } = buildFixture(
+        ['- [ ] Plain task 📅 2024-05-01'].join('\n'),
+      );
+      const file = {
+        path: 'notes.md',
+        vault: { getName: () => 'Personal & Work' },
+        // eslint-disable-next-line obsidianmd/no-tfile-tfolder-cast -- test fixture
+      } as unknown as TFile;
+
+      const finder = new TaskFinder(vault);
+      const tasks = await finder.findTasks(file, listItemsCache, undefined);
+
+      expect(tasks).toHaveLength(1);
+      expect(getFileUriFromTask(tasks[0])).toBe(
+        'obsidian://open?vault=Personal%20%26%20Work&file=notes.md',
+      );
+    });
+
+    it('percent-encodes ? in the file path', async () => {
+      const { vault, listItemsCache } = buildFixture(
+        ['- [ ] Plain task 📅 2024-05-01'].join('\n'),
+      );
+      const file = {
+        path: 'Where is my note?.md',
+        vault: { getName: () => 'v' },
+        // eslint-disable-next-line obsidianmd/no-tfile-tfolder-cast -- test fixture
+      } as unknown as TFile;
+
+      const finder = new TaskFinder(vault);
+      const tasks = await finder.findTasks(file, listItemsCache, undefined);
+
+      expect(getFileUriFromTask(tasks[0])).toBe(
+        'obsidian://open?vault=v&file=Where%20is%20my%20note%3F.md',
+      );
+    });
+
+    it('percent-encodes , in the file path', async () => {
+      const { vault, listItemsCache } = buildFixture(
+        ['- [ ] Plain task 📅 2024-05-01'].join('\n'),
+      );
+      const file = {
+        path: 'Meeting, 2024.md',
+        vault: { getName: () => 'v' },
+        // eslint-disable-next-line obsidianmd/no-tfile-tfolder-cast -- test fixture
+      } as unknown as TFile;
+
+      const finder = new TaskFinder(vault);
+      const tasks = await finder.findTasks(file, listItemsCache, undefined);
+
+      expect(getFileUriFromTask(tasks[0])).toBe(
+        'obsidian://open?vault=v&file=Meeting%2C%202024.md',
+      );
+    });
+
+    it('leaves a plain file path unchanged (only the / separators stay)', async () => {
+      const { vault, listItemsCache } = buildFixture(
+        ['- [ ] Plain task 📅 2024-05-01'].join('\n'),
+      );
+      const file = {
+        path: 'folder/notes.md',
+        vault: { getName: () => 'v' },
+        // eslint-disable-next-line obsidianmd/no-tfile-tfolder-cast -- test fixture
+      } as unknown as TFile;
+
+      const finder = new TaskFinder(vault);
+      const tasks = await finder.findTasks(file, listItemsCache, undefined);
+
+      // encodeURIComponent encodes / to %2F, which is intentional for URL safety.
+      expect(getFileUriFromTask(tasks[0])).toBe(
+        'obsidian://open?vault=v&file=folder%2Fnotes.md',
+      );
+    });
+  });
+
   it('with Day Planner DISABLED the heading-derived override never applies', async () => {
     mockSettings.isDayPlannerPluginFormatEnabled = false;
 


### PR DESCRIPTION
## Summary
- `TaskFinder.findTasks` builds `fileUri` with `encodeURIComponent` on both the vault name and the file path
- 4 new tests in `TaskFinder.test.ts` covering `&` in vault names, `?` `,` `/` in file paths

## Why
Plain concatenation produced malformed URLs for names containing `&`, `?`, `#`, `+`, `=`, or spaces. The downstream `encodeURI` in IcalService doesn't compensate — it only percent-encodes a narrow set of characters and leaves URL-reserved chars untouched.

After this fix the URL is properly encoded at construction time, so calendar apps can open the file when the user clicks through. `encodeURI` later becomes a no-op on the already-encoded string.

## Test plan
- [x] `bun run lint` — 0 errors
- [x] `bun run test` — Jest: 249/249 pass (4 new tests)
- [x] `bun test` — bun native: 102/102 pass
- [x] `bun run build` — clean

Fixes #210