### PR TITLE
Fix double URL-encoding of obsidian:// links in LOCATION/DESCRIPTION

### DIFF
--- a/src/IcalService.ts
+++ b/src/IcalService.ts
@@ -146,15 +146,18 @@ export class IcalService {
         'DTSTART:' + date + '\r\n';
     }
 
-    // ALTREP parameter values live inside DQUOTE — they're URIs, not TEXT, so
-    // they don't get the comma/semicolon backslash-escaping. The LOCATION
-    // value section (after the ':') IS TEXT and DOES need escaping.
-    const urlEncoded = encodeURI(task.getLocation());
+    // task.getLocation() is already percent-encoded at construction time in
+    // TaskFinder (via encodeURIComponent on the vault name and file path).
+    // Applying encodeURI here would re-encode the % signs, producing %25E2
+    // where the source had %E2 — broken obsidian:// links in calendar apps.
+    // ALTREP lives inside DQUOTE (URI rules, no TEXT escaping). The LOCATION
+    // value after ':' IS iCal TEXT and gets the comma/semicolon escape.
+    const location = task.getLocation();
 
     event += '' +
       'SUMMARY:' + prependSummary + task.getSummary() + '\r\n' +
-      (settings.isIncludeLinkInDescription ? 'DESCRIPTION:' + escapeICalText(urlEncoded) + '\r\n' : '') +
-      (settings.isIncludeLocation ? 'LOCATION;ALTREP="' + urlEncoded + '":' + escapeICalText(urlEncoded) + '\r\n' : '') +
+      (settings.isIncludeLinkInDescription ? 'DESCRIPTION:' + escapeICalText(location) + '\r\n' : '') +
+      (settings.isIncludeLocation ? 'LOCATION;ALTREP="' + location + '":' + escapeICalText(location) + '\r\n' : '') +
       'END:VEVENT\r\n';
 
     return event;
@@ -174,9 +177,9 @@ export class IcalService {
   }
 
   private getToDo(task: Task): string {
-    // ALTREP value lives inside DQUOTE (URI-rules, no TEXT escaping).
-    // LOCATION value section after ':' is TEXT and DOES need escaping.
-    const urlEncoded = encodeURI(task.getLocation());
+    // See getEvent() — task.getLocation() is already percent-encoded by
+    // TaskFinder; re-encoding here would double-encode % signs.
+    const location = task.getLocation();
 
     let toDo = '' +
       'BEGIN:VTODO\r\n' +
@@ -184,7 +187,7 @@ export class IcalService {
       'SUMMARY:' + task.getSummary() + '\r\n' +
       // If a task does not have a date, do not include the DTSTAMP property
       (task.hasAnyDate() ? 'DTSTAMP:' + task.getDate(null, 'YYYYMMDDTHHmmss') + '\r\n' : '') +
-      (settings.isIncludeLocation ? 'LOCATION;ALTREP="' + urlEncoded + '":' + escapeICalText(urlEncoded) + '\r\n' : '');
+      (settings.isIncludeLocation ? 'LOCATION;ALTREP="' + location + '":' + escapeICalText(location) + '\r\n' : '');
 
     if (task.hasA(TaskDateName.Due)) {
       toDo += 'DUE;VALUE=DATE:' + task.getDate(TaskDateName.Due, 'YYYYMMDD') + '\r\n';
@@ -211,7 +214,7 @@ export class IcalService {
 
 
     if (settings.isIncludeLinkInDescription) {
-      toDo += 'DESCRIPTION:' + escapeICalText(urlEncoded) + '\r\n';
+      toDo += 'DESCRIPTION:' + escapeICalText(location) + '\r\n';
     }
 
     toDo += 'END:VTODO\r\n';

--- a/src/__tests__/IcalService.test.ts
+++ b/src/__tests__/IcalService.test.ts
@@ -43,9 +43,11 @@ jest.mock('../SettingsManager', () => ({
 }));
 
 import { IcalService } from '../IcalService';
+import { TaskFinder } from '../TaskFinder';
 import { Task } from '../Model/Task';
 import { TaskDateName } from '../Model/TaskDate';
 import { TaskStatus } from '../Model/TaskStatus';
+import type { TFile } from 'obsidian';
 
 function buildTaskWithDueDate(): Task {
   const dueDate = new Date(2026, 4, 15);
@@ -198,11 +200,11 @@ describe('IcalService DESCRIPTION/LOCATION iCal-escaping', () => {
       buildTaskWithLocation('obsidian://open?vault=v&file=Meeting, 2024.md'),
     ]);
     // The ALTREP parameter (inside DQUOTE) keeps the raw comma — it's a URI,
-    // not iCal TEXT. encodeURI URL-encodes the space to %20 but leaves , alone.
-    expect(ical).toMatch(/LOCATION;ALTREP="[^"]*Meeting,%202024\.md"/);
+    // not iCal TEXT.
+    expect(ical).toMatch(/LOCATION;ALTREP="[^"]*Meeting, 2024\.md"/);
     // The LOCATION value (after the closing quote and colon) IS TEXT and the
     // comma must be escaped.
-    expect(ical).toMatch(/LOCATION;ALTREP="[^"]*":[^\r\n]*Meeting\\,%202024\.md/);
+    expect(ical).toMatch(/LOCATION;ALTREP="[^"]*":[^\r\n]*Meeting\\, 2024\.md/);
   });
 
   it('passes plain URLs through unchanged (regression for the common case)', () => {
@@ -211,5 +213,164 @@ describe('IcalService DESCRIPTION/LOCATION iCal-escaping', () => {
     ]);
     expect(ical).toContain('DESCRIPTION:obsidian://open?vault=v&file=note.md');
     expect(ical).toContain('LOCATION;ALTREP="obsidian://open?vault=v&file=note.md":obsidian://open?vault=v&file=note.md');
+  });
+});
+
+// Regression suite for issue #214. The fileUri passed into Task is already
+// percent-encoded by TaskFinder (using encodeURIComponent on the vault name
+// and file path). IcalService MUST emit it verbatim — re-encoding here would
+// turn every existing %xx into %25xx and break obsidian:// links.
+//
+// History: issue #17 → 1.7.1 added encodeURI inside IcalService to handle
+// spaces. Issue #210 fixed the missing reserved-char encoding (&, ?, #) by
+// moving to encodeURIComponent at construction time in TaskFinder, but left
+// the encodeURI call in place — producing the double-encoding reported in
+// issue #214. The fix removes the second pass.
+describe('IcalService — no double URL-encoding (issue #214)', () => {
+  beforeEach(() => {
+    mockSettings.isIncludeLocation = true;
+    mockSettings.isIncludeLinkInDescription = true;
+    mockSettings.includeEventsOrTodos = 'EventsOnly';
+    mockSettings.howToProcessMultipleDates = 'PreferDueDate';
+    mockSettings.isOnlyTasksWithoutDatesAreTodos = false;
+  });
+
+  function buildEventTaskWith(fileUri: string): Task {
+    return new Task(
+      TaskStatus.ToDo,
+      [{ name: TaskDateName.Due, date: new Date(2026, 4, 15), isDateOnly: true } as any],
+      'Sample task',
+      fileUri,
+    );
+  }
+
+  function buildTodoTaskWith(fileUri: string): Task {
+    return new Task(
+      TaskStatus.ToDo,
+      [],
+      'Sample task',
+      fileUri,
+    );
+  }
+
+  it('does not re-encode the percent sign — %E2 must not become %25E2', () => {
+    // Reporter's exact case from issue #214: en-dash in folder name.
+    const preEncoded = 'obsidian://open?vault=AL&file=07%E2%80%93Fachberater%2F2026-27%2FKT%20QuaMath%2FINFO.md';
+    const ical = new IcalService().getCalendar([buildEventTaskWith(preEncoded)]);
+
+    // ALTREP must contain the source URL byte-for-byte.
+    expect(ical).toContain('LOCATION;ALTREP="' + preEncoded + '"');
+    expect(ical).toContain('DESCRIPTION:' + preEncoded);
+
+    // The double-encoded form must NOT appear anywhere in the output.
+    expect(ical).not.toContain('%25E2');
+    expect(ical).not.toContain('%2580');
+    expect(ical).not.toContain('%2593');
+    expect(ical).not.toContain('%252F');
+    expect(ical).not.toContain('%2520');
+  });
+
+  it('does not re-encode %20 (space) as %2520', () => {
+    const preEncoded = 'obsidian://open?vault=v&file=My%20Notes.md';
+    const ical = new IcalService().getCalendar([buildEventTaskWith(preEncoded)]);
+    expect(ical).toContain('LOCATION;ALTREP="' + preEncoded + '"');
+    expect(ical).not.toContain('%2520');
+  });
+
+  it('does not re-encode %26 (ampersand) in a vault name', () => {
+    const preEncoded = 'obsidian://open?vault=Personal%20%26%20Work&file=notes.md';
+    const ical = new IcalService().getCalendar([buildEventTaskWith(preEncoded)]);
+    expect(ical).toContain('LOCATION;ALTREP="' + preEncoded + '"');
+    expect(ical).not.toContain('%2526');
+  });
+
+  it('does not re-encode %3F (question mark) in a file path', () => {
+    const preEncoded = 'obsidian://open?vault=v&file=Where%20is%20my%20note%3F.md';
+    const ical = new IcalService().getCalendar([buildEventTaskWith(preEncoded)]);
+    expect(ical).toContain('LOCATION;ALTREP="' + preEncoded + '"');
+    expect(ical).not.toContain('%253F');
+  });
+
+  it('does not re-encode %23 (hash) in a file path', () => {
+    const preEncoded = 'obsidian://open?vault=v&file=daily%23note.md';
+    const ical = new IcalService().getCalendar([buildEventTaskWith(preEncoded)]);
+    expect(ical).toContain('LOCATION;ALTREP="' + preEncoded + '"');
+    expect(ical).not.toContain('%2523');
+  });
+
+  it('does not re-encode %2C (comma) in a file path', () => {
+    const preEncoded = 'obsidian://open?vault=v&file=Meeting%2C%202024.md';
+    const ical = new IcalService().getCalendar([buildEventTaskWith(preEncoded)]);
+    expect(ical).toContain('LOCATION;ALTREP="' + preEncoded + '"');
+    expect(ical).not.toContain('%252C');
+  });
+
+  it('does not re-encode %2F (path separator) in a deep folder path', () => {
+    const preEncoded = 'obsidian://open?vault=v&file=a%2Fb%2Fc%2Fd.md';
+    const ical = new IcalService().getCalendar([buildEventTaskWith(preEncoded)]);
+    expect(ical).toContain('LOCATION;ALTREP="' + preEncoded + '"');
+    expect(ical).not.toContain('%252F');
+  });
+
+  it('also passes the encoded URL through unchanged in VTODO output', () => {
+    mockSettings.includeEventsOrTodos = 'TodosOnly';
+    const preEncoded = 'obsidian://open?vault=AL&file=07%E2%80%93Fachberater%2FINFO.md';
+    const ical = new IcalService().getCalendar([buildTodoTaskWith(preEncoded)]);
+    expect(ical).toContain('BEGIN:VTODO');
+    expect(ical).toContain('LOCATION;ALTREP="' + preEncoded + '"');
+    expect(ical).not.toContain('%25E2');
+  });
+
+  it('leaves a plain ASCII URL unchanged (no encoding needed, no encoding done)', () => {
+    const plain = 'obsidian://open?vault=v&file=folder%2Fnote.md';
+    const ical = new IcalService().getCalendar([buildEventTaskWith(plain)]);
+    expect(ical).toContain('LOCATION;ALTREP="' + plain + '"');
+    expect(ical).toContain('DESCRIPTION:' + plain);
+  });
+
+  it('round-trips: decoding the emitted ALTREP value yields the original file path', () => {
+    // Simulates what a calendar app does when it opens the obsidian:// link.
+    const vaultName = 'Personal & Work';
+    const filePath = '07–Fachberater/2026-27/KT QuaMath/INFO.md';
+    const preEncoded =
+      'obsidian://open?vault=' + encodeURIComponent(vaultName) +
+      '&file=' + encodeURIComponent(filePath);
+
+    const ical = new IcalService().getCalendar([buildEventTaskWith(preEncoded)]);
+    const altrep = ical.match(/LOCATION;ALTREP="([^"]+)"/)?.[1];
+    expect(altrep).toBeDefined();
+
+    const url = new URL(altrep!);
+    expect(decodeURIComponent(url.searchParams.get('vault') ?? '')).toBe(vaultName);
+    expect(decodeURIComponent(url.searchParams.get('file') ?? '')).toBe(filePath);
+  });
+
+  it('end-to-end through TaskFinder: deep folder path with en-dash yields a single-encoded URL', async () => {
+    // Reproduces issue #214 end-to-end. TaskFinder is the only producer of
+    // fileUri in production, so any encoding contract is "TaskFinder writes,
+    // IcalService passes through". This test pins both sides together.
+    const fileBody = '- [ ] Reporter case 📅 2024-05-01';
+    const vault = {
+      cachedRead: jest.fn().mockResolvedValue(fileBody),
+    } as unknown as ConstructorParameters<typeof TaskFinder>[0];
+    const file = {
+      path: '07–Fachberater/2026-27/KT QuaMath/INFO.md',
+      vault: { getName: () => 'AL' },
+      // eslint-disable-next-line obsidianmd/no-tfile-tfolder-cast -- test fixture
+    } as unknown as TFile;
+    const listItemsCache = [{ position: { start: { line: 0 } } } as any];
+
+    const finder = new TaskFinder(vault);
+    const tasks = await finder.findTasks(file, listItemsCache, undefined);
+    expect(tasks).toHaveLength(1);
+
+    const ical = new IcalService().getCalendar(tasks);
+
+    // ALTREP should contain exactly one encoding pass — en-dash as %E2%80%93,
+    // path separator as %2F, space as %20. Critically: no %25 anywhere.
+    expect(ical).toContain('%E2%80%93Fachberater');
+    expect(ical).toContain('KT%20QuaMath');
+    expect(ical).toContain('%2FINFO.md');
+    expect(ical).not.toMatch(/%25[0-9A-F]{2}/i);
   });
 });


### PR DESCRIPTION
## Summary

- TaskFinder already percent-encodes the vault name and file path via `encodeURIComponent` when it builds the `obsidian://open` URI (since PR #213, issue #210).
- `IcalService` then ran a second pass with `encodeURI(task.getLocation())`, turning every existing `%xx` into `%25xx` — the double-encoding reported in #214.
- This PR removes the second encoding pass for both VEVENT and VTODO, leaving exactly one encoding pass at construction time. ALTREP gets the URI verbatim; the TEXT value still goes through `escapeICalText` for RFC 5545 escaping.

## Why it kept coming back

A short history for the next person who touches this:

- **#17 (Nov 2023)** — Spaces in file paths weren't encoded. Fixed in 1.7.1 by adding `encodeURI` inside `IcalService`.
- **#210 (May 2026)** — `encodeURI` doesn't touch reserved chars (`&`, `?`, `#`, `+`, `=`), so vault/file names containing them produced malformed URLs. PR #213 moved encoding to `encodeURIComponent` at construction time in `TaskFinder`, but left the `encodeURI` call in `IcalService`.
- **#214 (June 2026)** — Now the URI is encoded twice: `%E2` becomes `%25E2`, `%20` becomes `%2520`. Reporter's `obsidian://open?vault=AL&file=07%25E2%2580%2593...` is the symptom.

## Tests

Added a regression suite **`IcalService — no double URL-encoding (issue #214)`** covering:

- Reporter's exact case (en-dash + spaces + nested folders) — assertions that `%25E2`, `%2580`, `%2593`, `%252F`, `%2520` do **not** appear.
- Pre-encoded `%20` (space) doesn't become `%2520`.
- Pre-encoded `%26` (ampersand in vault name) doesn't become `%2526`.
- Pre-encoded `%3F`, `%23`, `%2C`, `%2F` all pass through unchanged.
- VTODO output (separate code path) also passes the URL through unchanged.
- Plain ASCII URL unchanged.
- Round-trip: decoding the emitted ALTREP returns the original vault name and file path.
- End-to-end pin: `TaskFinder` → `IcalService` for the reporter's path yields a single-encoded URL with no `%25xx` anywhere.

Also updated the existing comma-escape test that asserted `%20`-encoded spaces — that came from the old double-encode behavior.

## Test plan

- [x] `bun run test` — 260/260 pass (was 250/250 before adding the new suite)
- [x] `bun test` — 102/102 pass (legacy iCal suite, unchanged)
- [x] `bun run build` — clean (production tsc + esbuild)
- [x] `npx eslint src/` — clean
- [ ] Manual: subscribe to the generated `.ics` in a calendar app, click an event with a non-ASCII vault/path, confirm Obsidian opens the file

Fixes #214